### PR TITLE
Changed the AST to fix the Undyn object expression

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE KindSignatures #-}
+
 -- | Module defining AST after parsing.
 -- The parsing module defines a function |SourceCode -> AnnotatedProgram
 -- ParseAnnotations|.
@@ -12,46 +14,56 @@ module AST
 -- From |CoreAST| we get all basic blocks.
 import           CoreAST
 
--- | First AST after parsing
-data Expression a
-  = AccessObject (RHSObject Expression a)
-  | Constant Const a -- ^ | 24 : i8|
-  | ParensExpression (Expression a) a
-  | BinOp Op (Expression a) (Expression a) a
-  | ReferenceExpression (RHSObject Expression a) a
-  | DereferenceExpression (Expression a) a
-  | Casting (Expression a) TypeSpecifier a
-  | FunctionExpression Identifier [ Expression a ] a
-  -- FunctionExpression (FuncName a) [ Expression a ] a
-  -- These four constructors cannot be used on regular (primitive?) expressions
-  -- These two can only be used as the RHS of an assignment:
-  | VectorInitExpression (Expression a) ConstExpression a -- ^ Vector initializer, | (13 : i8) + (2 : i8)|
-  | FieldValuesAssignmentsExpression
-    Identifier -- ^ Structure type identifier
-    [FieldValueAssignment' Expression a] -- ^ Initial value of each field identifier
-    a
-  -- These two can only be used as the RHS of an assignment or as a case of a match expression:
-  | EnumVariantExpression
-    Identifier -- ^ Enum identifier
-    Identifier -- ^ Variant identifier
-    [ Expression a ] -- ^ list of expressions
-    a
-  | OptionVariantExpression (OptionVariant (Expression a)) a
+----------------------------------------
+-- | Assignable and /accessable/ values. LHS, referencable and accessable.
+-- |Object'| should not be invoked directly.
+data Object'
+    (exprI :: * -> *) -- ^ Types returning identifiers
+    (a :: *)
+  = Variable Identifier a
+  -- ^ Plain identifier |v|
+  | IdentifierExpression (exprI a) a
+  -- ^ Complex identifier expressions: objects in runtime.
+  -- Added to have something like `return (f().foo + 3)`
+  | VectorIndexExpression (Object' exprI a) (Expression a) a
+  -- ^ Array indexing | eI [ eIx ]|,
+  -- value |eI :: exprI a| is an identifier expression, could be a name or a
+  -- function call (depending on what |exprI| is)
+  | MemberAccess (Object' exprI a) Identifier a
+  -- ^ Data structure/Class access | eI.name |, same as before |ei :: exprI a| is an
+  -- expression identifier.
+  | MemberMethodAccess (Object' exprI a) Identifier [Expression a] a
+  -- ^ Class method access | eI.name(x_{1}, ... , x_{n})|
+  | Dereference (Object' exprI a) a
+  -- ^ Dereference | *eI |, |eI| is an identifier expression.
   deriving (Show, Functor)
 
+-- | |RHSObjects| do not make a difference between identifier expressions and
+-- regular expressions.
+newtype RHSObject a = RHS {unRHS :: Object' Expression a}
+  deriving (Show, Functor)
+-- | |LHSObjects| do not accept |IdentifierExpressions|, and thus, we use the
+-- (polymorphic) empty type |Empty|
+newtype LHSObject a = LHS {unLHS :: Object' Empty a}
+  deriving (Show, Functor)
+----------------------------------------
+
+
+type Expression = Expression' RHSObject
+
 type ReturnStmt = ReturnStmt' Expression
-type BlockRet = BlockRet' Expression
-type AnnASTElement = AnnASTElement' Expression
+type BlockRet = BlockRet' Expression LHSObject
+type AnnASTElement = AnnASTElement' Expression LHSObject
 type FieldValueAssignment = FieldValueAssignment' Expression
 type Global = Global' Expression
 
-type TypeDef a = TypeDef' Expression a
+type TypeDef a = TypeDef' Expression LHSObject a
 
-type ClassMember = ClassMember' Expression
+type ClassMember = ClassMember' Expression LHSObject
 
-type MatchCase = MatchCase' Expression
-type ElseIf = ElseIf' Expression
-type Statement = Statement' Expression
+type MatchCase = MatchCase' Expression LHSObject
+type ElseIf = ElseIf' Expression LHSObject
+type Statement = Statement' Expression LHSObject
 
-type AnnotatedProgram a = [AnnASTElement' Expression a]
-type Block a = Block' Expression a
+type AnnotatedProgram a = [AnnASTElement' Expression LHSObject a]
+type Block a = Block' Expression LHSObject a

--- a/src/Utils/AST.hs
+++ b/src/Utils/AST.hs
@@ -27,6 +27,13 @@ groundTyEq  _ _ = False
 -- forgetAnnotations :: AnnotatedProgram a -> Program
 -- forgetAnnotations = map (fmap (const ()))
 
+getObjectAnnotations :: Object' exprI a -> a
+getObjectAnnotations (Variable _ a)                = a
+getObjectAnnotations (IdentifierExpression _ a)    = a
+getObjectAnnotations (VectorIndexExpression _ _ a) = a
+getObjectAnnotations (MemberAccess _ _ a)          = a
+getObjectAnnotations (Dereference _ a)             = a
+
 -- | First annotation level.
 getAnnotations :: Expression a -> a
 getAnnotations (AccessObject (RHS obj))                 = getObjectAnnotations obj

--- a/src/Utils/CoreAST.hs
+++ b/src/Utils/CoreAST.hs
@@ -4,9 +4,3 @@ module Utils.CoreAST where
 
 import           CoreAST
 
-getObjectAnnotations :: Object' exprI exprE a -> a
-getObjectAnnotations (Variable _ a)                = a
-getObjectAnnotations (IdentifierExpression _ a)    = a
-getObjectAnnotations (VectorIndexExpression _ _ a) = a
-getObjectAnnotations (MemberAccess _ _ a)          = a
-getObjectAnnotations (Dereference _ a)             = a

--- a/src/Utils/SemanAST.hs
+++ b/src/Utils/SemanAST.hs
@@ -5,6 +5,14 @@ module Utils.SemanAST where
 import           SemanAST
 import           Utils.CoreAST
 
+getObjectAnnotations :: Object' exprI a -> a
+getObjectAnnotations (Variable _ a)                = a
+getObjectAnnotations (IdentifierExpression _ a)    = a
+getObjectAnnotations (VectorIndexExpression _ _ a) = a
+getObjectAnnotations (MemberAccess _ _ a)          = a
+getObjectAnnotations (Dereference _ a)             = a
+
+-- | First annotation level.
 getAnnotations :: Expression a -> a
 getAnnotations (AccessObject (RHS obj))                 = getObjectAnnotations obj
 getAnnotations (Constant _ a)                           = a
@@ -15,4 +23,3 @@ getAnnotations (FunctionExpression _ _ a)               = a
 getAnnotations (FieldValuesAssignmentsExpression _ _ a) = a
 getAnnotations (EnumVariantExpression _ _ _ a)          = a
 getAnnotations (VectorInitExpression _ _ a)             = a
-getAnnotations (Undyn _ a)             = a

--- a/src/Utils/TypeSpecifier.hs
+++ b/src/Utils/TypeSpecifier.hs
@@ -67,7 +67,7 @@ memberIntCons i Int32  = ( -2147483648 <= i ) && ( i <= 2147483647 )
 memberIntCons i Int64  = ( -9223372036854775808 <= i ) && ( i <= 9223372036854775807 )
 memberIntCons _ _      = False
 
-identifierType :: TypeDef' expr a -> Identifier
+identifierType :: TypeDef' expr lho a -> Identifier
 identifierType (Struct ident _ _) = ident
 identifierType (Union ident _ _)  = ident
 identifierType (Enum ident _ _)   = ident


### PR DESCRIPTION
Now the Undyn are object access expressions instead of regular expressions. The following changes have been applied to the code:

1) The data type Expression has been moved to CoreAST, changing the name to Expression'.
2) The new data type Expression' is parametric on the object data type. 3) Now both AST and SemanAST implement their own object data type which in turn depends on Expression 🙃.
4) Both data types only receive the type of Identifier Expressions and the type of annotations. The type of the expressions is fixed to Expression (Expression is a type alias of (Expression' RHSObject)).
5) Changed references to the objects in both the typechecker and the parser to make the typechecker work.

The src/Utils/CoreAST.hs file has been maintained despite being empty so that changes can be traced.