### PR TITLE
Updated the printer

### DIFF
--- a/src/PPrinter/Expression.hs
+++ b/src/PPrinter/Expression.hs
@@ -17,23 +17,23 @@ type Printer a =
   DocStyle
 
 ppBinaryOperator :: Op -> DocStyle
-ppBinaryOperator Multiplication = space <> pretty "*" <> space
-ppBinaryOperator Division = space <> pretty "/" <> space
-ppBinaryOperator Addition = space <> pretty "+" <> space
-ppBinaryOperator Subtraction = space <> pretty  "-" <> space
-ppBinaryOperator BitwiseLeftShift = space <> pretty  "<<" <> space
-ppBinaryOperator BitwiseRightShift = space <> pretty  ">>" <> space
-ppBinaryOperator RelationalLT = space <> pretty  "<" <> space
-ppBinaryOperator RelationalLTE = space <> pretty  "<=" <> space
-ppBinaryOperator RelationalGT = space <> pretty  ">" <> space
-ppBinaryOperator RelationalGTE = space <> pretty  ">=" <> space
-ppBinaryOperator RelationalEqual = space <> pretty  "==" <> space
-ppBinaryOperator RelationalNotEqual = space <> pretty  "!=" <> space
-ppBinaryOperator BitwiseAnd = space <> pretty  "&" <> space
-ppBinaryOperator BitwiseOr = space <> pretty  "|" <> space
-ppBinaryOperator BitwiseXor = space <> pretty  "^" <> space
-ppBinaryOperator LogicalAnd = space <> pretty  "&&" <> space
-ppBinaryOperator LogicalOr = space <> pretty  "||" <> space
+ppBinaryOperator Multiplication = pretty "*"
+ppBinaryOperator Division = pretty "/"
+ppBinaryOperator Addition = pretty "+"
+ppBinaryOperator Subtraction = pretty  "-"
+ppBinaryOperator BitwiseLeftShift = pretty  "<<"
+ppBinaryOperator BitwiseRightShift = pretty  ">>"
+ppBinaryOperator RelationalLT = pretty  "<"
+ppBinaryOperator RelationalLTE = pretty  "<="
+ppBinaryOperator RelationalGT = pretty  ">"
+ppBinaryOperator RelationalGTE = pretty  ">="
+ppBinaryOperator RelationalEqual = pretty  "=="
+ppBinaryOperator RelationalNotEqual = pretty  "!="
+ppBinaryOperator BitwiseAnd = pretty  "&"
+ppBinaryOperator BitwiseOr = pretty  "|"
+ppBinaryOperator BitwiseXor = pretty  "^"
+ppBinaryOperator LogicalAnd = pretty  "&&"
+ppBinaryOperator LogicalOr = pretty  "||"
 
 -- | Pretty prints the casting expression of a dynamic subtype
 ppDynamicSubtypeCast :: TypeSpecifier -> DocStyle
@@ -56,7 +56,7 @@ ppDynamicSubtypeObjectAddress :: Printer Object
 ppDynamicSubtypeObjectAddress subs obj =
     case getObjectType obj of
         DynamicSubtype ts ->
-            parens (ppDynamicSubtypeCast ts) <> ppObject subs obj <> pretty ".datum"
+            parens (ppDynamicSubtypeCast ts) <> ppObject subs obj <> pretty ".data"
         _ -> error "unsupported expression"
 
 ppRefDynamicSubtypeObjectAddress :: Printer Expression
@@ -67,7 +67,7 @@ ppRefDynamicSubtypeObjectAddress subs expr =
                 case expr of
                     (ReferenceExpression _ _) ->  parens (ppExpression subs expr)
                     _ -> ppExpression subs expr
-            ) <> pretty "->datum"
+            ) <> pretty "->data"
         _ -> error "unsupported expression"
 
 ppDynamicSubtypeObject :: Printer Object
@@ -133,9 +133,9 @@ ppObject subs (Dereference obj _) =
 -- check if it is a vector
 ppObject subs (Undyn obj _) =
     case getObjectType obj of
-        -- | If it is a vector, we need to print the address of the datum
+        -- | If it is a vector, we need to print the address of the data
         (DynamicSubtype (Vector _ _)) -> parens (ppDynamicSubtypeObjectAddress subs obj)
-        -- | Else, we print the derefence to the datum
+        -- | Else, we print the derefence to the data
         (DynamicSubtype _) -> ppDynamicSubtypeObject subs obj
         -- | An undyn can only be applied to a dynamic subtype. We are not
         -- supposed to reach here. If we are here, it means that the semantic
@@ -149,33 +149,33 @@ ppObject subs (ParensObject obj _) = parens (ppObject subs obj)
 ppExpression' :: Printer Expression
 ppExpression' subs expr@(BinOp Addition expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator Addition <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator Addition <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp Subtraction expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator Subtraction <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator Subtraction <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp Multiplication expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator Multiplication <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator Multiplication <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp Division expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator Division <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator Division <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp BitwiseLeftShift expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator BitwiseLeftShift <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator BitwiseLeftShift <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp BitwiseRightShift expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator BitwiseRightShift <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator BitwiseRightShift <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp BitwiseAnd expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator BitwiseAnd <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator BitwiseAnd <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp BitwiseOr expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator BitwiseOr <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator BitwiseOr <+> ppExpression' subs expr2)
 ppExpression' subs expr@(BinOp BitwiseXor expr1 expr2 _) =
     let ts = getType expr in
-        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <> ppBinaryOperator BitwiseXor <> ppExpression' subs expr2)
+        parens (ppTypeSpecifier ts) <> parens (ppExpression' subs expr1 <+> ppBinaryOperator BitwiseXor <+> ppExpression' subs expr2)
 ppExpression' subs (BinOp op expr1 expr2 _) =
-    ppExpression' subs expr1 <> ppBinaryOperator op <> ppExpression' subs expr2
+    ppExpression' subs expr1 <+> ppBinaryOperator op <+> ppExpression' subs expr2
 ppExpression' subs expr = ppExpression subs expr
 
 -- | Expression pretty printer
@@ -197,7 +197,7 @@ ppExpression _ (Constant constant _) =
         I ts' integer -> parens (ppTypeSpecifier ts') <> pretty integer
         C char -> squotes (pretty char)
 ppExpression subs (BinOp op expr1 expr2 _) =
-    ppExpression' subs expr1 <> ppBinaryOperator op <> ppExpression' subs expr2
+    ppExpression' subs expr1 <+> ppBinaryOperator op <+> ppExpression' subs expr2
 ppExpression subs (Casting expr' ts' _) =
     case expr' of
         (Constant (I _ integer) _) -> parens (ppTypeSpecifier ts') <> pretty integer
@@ -216,7 +216,9 @@ ppExpression subs expr@(FunctionExpression identifier params _) =
                             (parens (ppParameterVectorValueStructure (pretty identifier) (pretty pid) <+> pretty "*") <> parens (ppExpression subs p))
                     (_, _) -> ppExpression subs p) params paramAnns
     in
-    ppCFunctionCall (pretty identifier) ins
+        case getType expr of
+            Vector {} -> ppCFunctionCall (pretty identifier) ins <> pretty ".array"
+            _ -> ppCFunctionCall (pretty identifier) ins
 ppExpression subs (MemberMethodAccess obj methodId params _) =
     case getObjectType obj of
         (Reference ts) ->

--- a/src/PPrinter/Function.hs
+++ b/src/PPrinter/Function.hs
@@ -23,7 +23,7 @@ ppParameterSubstitutions parameters =
 
 ppFunction :: AnnASTElement SemanticAnns -> DocStyle
 ppFunction (Function identifier parameters rTS blk _ _) =
-  ppCFunctionDeclaration (pretty identifier)
+  ppCFunctionPrototype (pretty identifier)
     (ppParameterDeclaration (pretty identifier) <$> parameters)
     (ppReturnType (pretty identifier) <$> rTS)
     <+> ppBlockRet (ppParameterSubstitutions parameters) (pretty identifier) blk
@@ -32,9 +32,12 @@ ppFunction _ = error "AST element is not a function"
 ppFunctionDeclaration :: AnnASTElement SemanticAnns -> DocStyle
 ppFunctionDeclaration (Function identifier parameters rTS _ _ _) =
   vsep $ 
-  ([ppParameterVectorValueStructureDecl (pretty identifier) (pretty pid) ts <> line | (Parameter pid ts@(Vector {})) <- parameters]) ++ 
+  ([ppParameterVectorValueStructureDecl (pretty identifier) (pretty pid) ts <> line | (Parameter pid ts@(Vector {})) <- parameters]) ++
+  (case rTS of
+    Just ts@(Vector {}) -> [ppReturnVectorValueStructureDecl (pretty identifier) ts <> line]
+    _ -> []) ++
   [
-    ppCFunctionDeclaration (pretty identifier)
+    ppCFunctionPrototype (pretty identifier)
       (ppParameterDeclaration (pretty identifier) <$> parameters)
       (ppReturnType (pretty identifier) <$> rTS) <> semi,
     emptyDoc

--- a/src/PPrinter/Statement.hs
+++ b/src/PPrinter/Statement.hs
@@ -8,12 +8,6 @@ import Data.Map (union, fromList, empty)
 import PPrinter.Expression
 import PPrinter.Statement.VariableInitialization
 
-----------------------------------------
--- Convention
-freeWord :: DocStyle
-freeWord = pretty "__pool__free"
-----------------------------------------
-
 
 ppDeclareAndInitialize ::
     (DocStyle -> Expression SemanticAnns -> DocStyle)
@@ -40,15 +34,13 @@ ppReturnStmt :: DocStyle -> ReturnStmt SemanticAnns -> DocStyle
 ppReturnStmt identifier (ReturnStmt (Just expr) _) =
     case getType expr of
         (Vector {}) -> returnC <+> 
-            parens (ppReturnVectorValueStructure identifier <+> pretty "*") <> ppExpression empty expr <> semi
+            ppCDereferenceExpression (parens (ppReturnVectorValueStructure identifier <+> pretty "*") <> ppExpression empty expr) <> semi
         _ -> returnC <+> ppExpression empty expr <> semi
 ppReturnStmt _ (ReturnStmt Nothing _) = returnC <> semi
 
 ppStatement :: Substitutions -> Statement SemanticAnns -> DocStyle
--- TODO Pablo check it out please
 ppStatement subs (Free obj _) =
-  freeWord <+> parens (ppObject subs obj) <> semi
-----------------------------------------
+    ppCFunctionCall poolFree [ppObject subs obj] <> semi
 ppStatement subs (Declaration identifier ts expr _) =
   case ts of
     Vector _ _ -> 
@@ -65,7 +57,13 @@ ppStatement subs (AssignmentStmt obj expr  _) =
     let ts = getObjectType obj in
     case ts of
         Vector _ _ ->
-            braces' $ (indentTab . align) $ ppInitializeVector subs 0 (ppObject subs obj) expr
+            case expr of 
+                (FunctionExpression identifier _ _) -> 
+                    ppCDereferenceExpression
+                            (parens (ppReturnVectorValueStructure (pretty identifier) <+> pretty "*") <> parens (ppObject subs obj))
+                    <+> pretty "=" <+> ppCDereferenceExpression
+                            (parens (ppReturnVectorValueStructure (pretty identifier) <+> pretty "*") <> parens (ppExpression subs expr)) <> semi
+                _ -> braces' $ (indentTab . align) $ ppInitializeVector subs 0 (ppObject subs obj) expr
         _ -> case expr of
             (FieldValuesAssignmentsExpression {}) ->
                 braces' $ (indentTab . align) $ ppInitializeStruct subs 0 (ppObject subs obj) expr

--- a/src/PPrinter/Statement/VariableInitialization.hs
+++ b/src/PPrinter/Statement/VariableInitialization.hs
@@ -66,6 +66,11 @@ ppInitializeVector subs level target expr =
                         ( ppInitializeVector subs (level + 1) (target <> brackets (pretty iterator)) expr'
                         )
         (EnumVariantExpression {}) -> ppInitializeEnum subs level target expr
+        (FunctionExpression identifier _ _) ->
+          ppCDereferenceExpression
+            (parens (ppReturnVectorValueStructure (pretty identifier) <+> pretty "*") <> parens target)
+            <+> pretty "=" <+> ppCDereferenceExpression
+            (parens (ppReturnVectorValueStructure (pretty identifier) <+> pretty "*") <> parens (ppExpression subs expr)) <> semi
         _ -> ppInitializeVectorFromExpression level target (ppExpression subs expr) (getType expr)
 
 ppFieldInitializer :: Substitutions ->  Integer -> DocStyle -> DocStyle -> Expression SemanticAnns -> DocStyle

--- a/src/PPrinter/Task.hs
+++ b/src/PPrinter/Task.hs
@@ -9,7 +9,7 @@ import PPrinter.Function
 
 ppTask :: AnnASTElement SemanticAnns -> DocStyle
 ppTask (Task identifier parameters rTS blk _ _) =
-  ppCFunctionDeclaration (pretty identifier)
+  ppCFunctionPrototype (pretty identifier)
     (ppParameterDeclaration (pretty identifier) <$> parameters)
     (Just (ppReturnType (pretty identifier) rTS))
     <+> ppBlockRet (ppParameterSubstitutions parameters) (pretty identifier) blk
@@ -20,7 +20,7 @@ ppTaskDeclaration (Task identifier parameters rTS _ _ _) =
   vsep $ 
   ([ppParameterVectorValueStructureDecl (pretty identifier) (pretty pid) ts <> line | (Parameter pid ts@(Vector {})) <- parameters]) ++ 
   [
-    ppCFunctionDeclaration (pretty identifier)
+    ppCFunctionPrototype (pretty identifier)
       (ppParameterDeclaration (pretty identifier) <$> parameters)
       (Just (ppReturnType (pretty identifier) rTS)) <> semi
   ]

--- a/src/PPrinter/TypeDef.hs
+++ b/src/PPrinter/TypeDef.hs
@@ -18,7 +18,7 @@ classMethodNameAOp ident = (pretty ("__" ++ ident ++ "_") <>) . methodAccessOp
 
 ppClassMethodDeclaration :: Identifier -> ClassMember a -> DocStyle
 ppClassMethodDeclaration classId (ClassMethod methodId parameters _ _ _) =
-  ppCFunctionDeclaration (classMethodName classId methodId)
+  ppCFunctionPrototype (classMethodName classId methodId)
     (map (ppParameterDeclaration (pretty (classId ++ "_" ++ methodId))) parameters) Nothing <> semi
 ppClassMethodDeclaration _ _ = error "invalid class member"
 

--- a/test/IT/Expression/ArithmeticSpec.hs
+++ b/test/IT/Expression/ArithmeticSpec.hs
@@ -83,26 +83,26 @@ spec = do
               "}\n")    
     it "Prints declaration of function test1" $ do
      renderHeader test1 `shouldBe`
-       pack "void test1(__dyn_t foo);\n"
+       pack "void test1(__termina_dyn_t foo);\n"
     it "Prints definition of function test1" $ do
      renderSource test1 `shouldBe`
-       pack ("void test1(__dyn_t foo) {\n" ++
+       pack ("void test1(__termina_dyn_t foo) {\n" ++
              "    \n" ++
-             "    *((uint16_t *)foo.datum) = *((uint16_t *)foo.datum) + (uint16_t)1024;\n" ++
+             "    *((uint16_t *)foo.data) = *((uint16_t *)foo.data) + (uint16_t)1024;\n" ++
              "\n" ++
-             "    (uint16_t)1024 + *((uint16_t *)foo.datum);\n" ++
+             "    (uint16_t)1024 + *((uint16_t *)foo.data);\n" ++
              "\n" ++
-             "    *((uint16_t *)foo.datum) = *((uint16_t *)foo.datum) - (uint16_t)1024;\n" ++
+             "    *((uint16_t *)foo.data) = *((uint16_t *)foo.data) - (uint16_t)1024;\n" ++
              "\n" ++
-             "    (uint16_t)1024 - *((uint16_t *)foo.datum);\n" ++
+             "    (uint16_t)1024 - *((uint16_t *)foo.data);\n" ++
              "\n" ++
-             "    *((uint16_t *)foo.datum) = *((uint16_t *)foo.datum) * (uint16_t)1024;\n" ++
+             "    *((uint16_t *)foo.data) = *((uint16_t *)foo.data) * (uint16_t)1024;\n" ++
              "\n" ++
-             "    (uint16_t)1024 * *((uint16_t *)foo.datum);\n" ++
+             "    (uint16_t)1024 * *((uint16_t *)foo.data);\n" ++
              "\n" ++
-             "    *((uint16_t *)foo.datum) = *((uint16_t *)foo.datum) / (uint16_t)1024;\n" ++
+             "    *((uint16_t *)foo.data) = *((uint16_t *)foo.data) / (uint16_t)1024;\n" ++
              "\n" ++
-             "    (uint16_t)1024 / *((uint16_t *)foo.datum);\n" ++
+             "    (uint16_t)1024 / *((uint16_t *)foo.data);\n" ++
              "\n" ++
              "    return;\n" ++
              "\n" ++

--- a/test/IT/Expression/FunctionCallSpec.hs
+++ b/test/IT/Expression/FunctionCallSpec.hs
@@ -8,13 +8,26 @@ import Text.Parsec
 import Semantic.TypeChecking
 
 test0 :: String
-test0 = "fn test0(a : u16) -> u16 {\n" ++
+test0 = "fn func_test0_0(a : u16) -> u16 {\n" ++
         "    return (a + (1 : u16));\n" ++
         "}\n" ++
         "\n" ++
-        "fn test1(a : u16) -> u16 {\n" ++
-        "    var foo : u16 = test0(2 : u16);\n" ++
+        "fn func_test0_1(a : u16) -> u16 {\n" ++
+        "    var foo : u16 = func_test0_0(2 : u16);\n" ++
         "    return (foo * (2 : u16));\n" ++
+        "}"
+
+test1 :: String
+test1 = "fn func_test1_0() -> [u32; 10 : u32] {\n" ++
+        "    var foo : [u32; 10 : u32] = [1024 : u32; 10 : u32];\n" ++
+        "    return foo;\n" ++
+        "}\n" ++
+        "\n" ++
+        "fn func_test1_1() -> u32 {\n" ++
+        "    var bar0 : [u32; 10 : u32] = [0 : u32; 10 : u32];\n" ++
+        "    bar0 = func_test1_0();\n" ++
+        "    var bar1 : [u32; 10 : u32] = func_test1_0();\n" ++
+        "    return bar0[1 : u32] + bar1[2 : u32];\n" ++
         "}"
 
 renderHeader :: String -> Text
@@ -36,23 +49,69 @@ renderSource input = case parse (contents topLevel) "" input of
 spec :: Spec
 spec = do
   describe "Pretty printing function call expressions" $ do
-    it "Prints declaration of functions test0 and test1" $ do
+    it "Prints declaration of functions of test0" $ do
       renderHeader test0 `shouldBe`
-        pack ("uint16_t test0(uint16_t a);\n\n" ++
-              "uint16_t test1(uint16_t a);\n")
-    it "Prints definition of functions test0 and test1" $ do
+        pack ("uint16_t func_test0_0(uint16_t a);\n\n" ++
+              "uint16_t func_test0_1(uint16_t a);\n")
+    it "Prints definition of functions of test0" $ do
       renderSource test0 `shouldBe`
-        pack ("uint16_t test0(uint16_t a) {\n" ++
+        pack ("uint16_t func_test0_0(uint16_t a) {\n" ++
               "    \n" ++
               "\n" ++
               "    return (a + ((uint16_t)1));\n" ++
               "\n" ++
               "}\n" ++
               "\n" ++
-              "uint16_t test1(uint16_t a) {\n" ++
+              "uint16_t func_test0_1(uint16_t a) {\n" ++
               "    \n" ++
-              "    uint16_t foo = test0((uint16_t)2);\n" ++
+              "    uint16_t foo = func_test0_0((uint16_t)2);\n" ++
               "\n" ++
               "    return (foo * ((uint16_t)2));\n" ++
+              "\n" ++
+              "}\n")    
+    it "Prints declaration of functions test0 and test1" $ do
+      renderHeader test1 `shouldBe`
+        pack ("typedef struct {\n" ++
+              "    uint32_t array[10];\n" ++
+              "} __ret_func_test1_0_t;\n" ++
+              "\n" ++
+              "__ret_func_test1_0_t func_test1_0();\n" ++
+              "\n" ++
+              "uint32_t func_test1_1();\n")
+    it "Prints definition of functions test0 and test1" $ do
+      renderSource test1 `shouldBe`
+        pack ("__ret_func_test1_0_t func_test1_0() {\n" ++
+              "    \n" ++
+              "    uint32_t foo[10];\n" ++
+              "\n" ++
+              "    {\n" ++
+              "        for (uint32_t __i0 = 0; __i0 < (uint32_t)10; __i0 = __i0 + (uint32_t)1) {\n" ++
+              "            foo[__i0] = (uint32_t)1024;\n" ++
+              "        }\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    return *((__ret_func_test1_0_t *)foo);\n" ++
+              "\n" ++
+              "}\n" ++
+              "\n" ++
+              "uint32_t func_test1_1() {\n" ++
+              "    \n" ++
+              "    uint32_t bar0[10];\n" ++
+              "\n" ++
+              "    {\n" ++
+              "        for (uint32_t __i0 = 0; __i0 < (uint32_t)10; __i0 = __i0 + (uint32_t)1) {\n" ++
+              "            bar0[__i0] = (uint32_t)0;\n" ++
+              "        }\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    *((__ret_func_test1_0_t *)(bar0)) = *((__ret_func_test1_0_t *)(func_test1_0().array));\n" ++
+              "\n" ++
+              "    uint32_t bar1[10];\n" ++
+              "\n" ++
+              "    {\n" ++
+              "        *((__ret_func_test1_0_t *)(bar1)) = *((__ret_func_test1_0_t *)(func_test1_0().array));\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    return bar0[(uint32_t)1] + bar1[(uint32_t)2];\n" ++
               "\n" ++
               "}\n")    

--- a/test/IT/Global/PoolSpec.hs
+++ b/test/IT/Global/PoolSpec.hs
@@ -23,6 +23,7 @@ test0 = "enum Message {\n" ++
         "    match alloc_msg {\n" ++
         "        case Some(msg) => {\n" ++
         "            msg = Message::In(in0, in1);\n" ++
+        "            free(msg);\n" ++
         "        }\n" ++
         "        case None => {\n" ++
         "        }\n" ++
@@ -81,13 +82,13 @@ spec = do
       renderSource test0 `shouldBe`
         pack ("void test0(uint32_t in0, uint32_t in1) {\n" ++
               "    \n" ++
-              "    __Option_dyn_t alloc_msg;\n" ++
+              "    __termina_option_dyn_t alloc_msg;\n" ++
               "\n" ++
               "    {\n" ++
               "        alloc_msg.__variant = None;\n" ++
               "    }\n" ++
               "\n" ++
-              "    __pool_alloc(&message_pool, &alloc_msg);\n" ++
+              "    __termina_pool_alloc(&message_pool, &alloc_msg);\n" ++
               "\n" ++
               "    if (alloc_msg.__variant == None) {\n" ++
               "\n" ++
@@ -95,10 +96,12 @@ spec = do
               "    } else {\n" ++
               "\n" ++
               "        {\n" ++
-              "            *((Message *)alloc_msg.__Some.__0.datum).__variant = In;\n" ++
-              "            *((Message *)alloc_msg.__Some.__0.datum).__In.__0 = in0;\n" ++
-              "            *((Message *)alloc_msg.__Some.__0.datum).__In.__1 = in1;\n" ++
+              "            *((Message *)alloc_msg.__Some.__0.data).__variant = In;\n" ++
+              "            *((Message *)alloc_msg.__Some.__0.data).__In.__0 = in0;\n" ++
+              "            *((Message *)alloc_msg.__Some.__0.data).__In.__1 = in1;\n" ++
               "        }\n" ++
+              "\n" ++
+              "        __termina_pool_free(alloc_msg.__Some.__0);\n" ++
               "\n" ++
               "    }\n" ++
               "\n" ++

--- a/test/IT/Statement/AssignmentSpec.hs
+++ b/test/IT/Statement/AssignmentSpec.hs
@@ -77,12 +77,12 @@ spec = do
               "}\n")    
     it "Prints declaration of function assignment_test1" $ do
      renderHeader test1 `shouldBe`
-       pack "void assignment_test1(__dyn_t dyn_var0);\n"
+       pack "void assignment_test1(__termina_dyn_t dyn_var0);\n"
     it "Prints definition of function assignment_test1" $ do
      renderSource test1 `shouldBe`
-        pack ("void assignment_test1(__dyn_t dyn_var0) {\n" ++
+        pack ("void assignment_test1(__termina_dyn_t dyn_var0) {\n" ++
               "    \n" ++
-              "    __Option_dyn_t option;\n" ++
+              "    __termina_option_dyn_t option;\n" ++
               "\n" ++
               "    {\n" ++
               "        option.__variant = None;\n" ++
@@ -98,28 +98,28 @@ spec = do
               "}\n")  
     it "Prints declaration of function assignment_test2" $ do
      renderHeader test2 `shouldBe`
-       pack "void assignment_test2(__dyn_t dyn_var0, __dyn_t dyn_var1);\n"
+       pack "void assignment_test2(__termina_dyn_t dyn_var0, __termina_dyn_t dyn_var1);\n"
     it "Prints definition of function assignment_test2" $ do
      renderSource test2 `shouldBe`
-        pack ("void assignment_test2(__dyn_t dyn_var0, __dyn_t dyn_var1) {\n" ++
+        pack ("void assignment_test2(__termina_dyn_t dyn_var0, __termina_dyn_t dyn_var1) {\n" ++
               "    \n" ++
               "    uint32_t foo = (uint32_t)0;\n" ++
               "\n" ++
-              "    *((uint32_t *)dyn_var0.datum) = foo;\n" ++
+              "    *((uint32_t *)dyn_var0.data) = foo;\n" ++
               "\n" ++
-              "    foo = *((uint32_t *)dyn_var1.datum);\n" ++
+              "    foo = *((uint32_t *)dyn_var1.data);\n" ++
               "\n" ++
-              "    *((uint32_t *)dyn_var1.datum) = *((uint32_t *)dyn_var0.datum);\n" ++
+              "    *((uint32_t *)dyn_var1.data) = *((uint32_t *)dyn_var0.data);\n" ++
               "\n" ++
               "    return;\n" ++
               "\n" ++
               "}\n")  
     it "Prints declaration of function assignment_test3" $ do
      renderHeader test3 `shouldBe`
-       pack "void assignment_test3(__dyn_t dyn_var0, __dyn_t dyn_var1);\n"
+       pack "void assignment_test3(__termina_dyn_t dyn_var0, __termina_dyn_t dyn_var1);\n"
     it "Prints definition of function assignment_test2" $ do
      renderSource test3 `shouldBe`
-        pack ("void assignment_test3(__dyn_t dyn_var0, __dyn_t dyn_var1) {\n" ++
+        pack ("void assignment_test3(__termina_dyn_t dyn_var0, __termina_dyn_t dyn_var1) {\n" ++
               "    \n" ++
               "    uint32_t foo[10];\n" ++
               "\n" ++
@@ -131,19 +131,19 @@ spec = do
               "\n" ++
               "    {\n" ++
               "        for (uint32_t __i0 = 0; __i0 < (uint32_t)10; __i0 = __i0 + (uint32_t)1) {\n" ++
-              "            ((uint32_t *)dyn_var0.datum)[__i0] = foo[__i0];\n" ++
+              "            ((uint32_t *)dyn_var0.data)[__i0] = foo[__i0];\n" ++
               "        }\n" ++
               "    }\n" ++
               "\n" ++
               "    {\n" ++
               "        for (uint32_t __i0 = 0; __i0 < (uint32_t)10; __i0 = __i0 + (uint32_t)1) {\n" ++
-              "            foo[__i0] = ((uint32_t *)dyn_var1.datum)[__i0];\n" ++
+              "            foo[__i0] = ((uint32_t *)dyn_var1.data)[__i0];\n" ++
               "        }\n" ++
               "    }\n" ++
               "\n" ++
               "    {\n" ++
               "        for (uint32_t __i0 = 0; __i0 < (uint32_t)10; __i0 = __i0 + (uint32_t)1) {\n" ++
-              "            ((uint32_t *)dyn_var1.datum)[__i0] = ((uint32_t *)dyn_var0.datum)[__i0];\n" ++
+              "            ((uint32_t *)dyn_var1.data)[__i0] = ((uint32_t *)dyn_var0.data)[__i0];\n" ++
               "        }\n" ++
               "    }\n" ++
               "\n" ++

--- a/test/IT/Statement/ForLoopSpec.hs
+++ b/test/IT/Statement/ForLoopSpec.hs
@@ -50,12 +50,12 @@ spec = do
       renderHeader test0 `shouldBe`
         pack ("typedef struct {\n" ++
               "    uint16_t array[10];\n" ++
-              "} __param__for_loop_test0__array0_t;\n" ++
+              "} __param_for_loop_test0_array0_t;\n" ++
               "\n" ++
-              "uint16_t for_loop_test0(__param__for_loop_test0__array0_t array0);\n")
+              "uint16_t for_loop_test0(__param_for_loop_test0_array0_t array0);\n")
     it "Prints definition of function for_loop_test0_test0" $ do
       renderSource test0 `shouldBe`
-        pack ("uint16_t for_loop_test0(__param__for_loop_test0__array0_t array0) {\n" ++
+        pack ("uint16_t for_loop_test0(__param_for_loop_test0_array0_t array0) {\n" ++
               "    \n" ++
               "    uint16_t total = (uint16_t)0;\n" ++
               "\n" ++

--- a/test/IT/Statement/MatchSpec.hs
+++ b/test/IT/Statement/MatchSpec.hs
@@ -83,10 +83,10 @@ spec = do
   describe "Pretty printing match statements" $ do
     it "Prints declaration of function match_test0" $ do
       renderHeader test0 `shouldBe`
-        pack "uint32_t match_test0(__Option_dyn_t option0);\n"
+        pack "uint32_t match_test0(__termina_option_dyn_t option0);\n"
     it "Prints definition of function match_test0" $ do
       renderSource test0 `shouldBe`
-        pack ("uint32_t match_test0(__Option_dyn_t option0) {\n" ++
+        pack ("uint32_t match_test0(__termina_option_dyn_t option0) {\n" ++
               "    \n" ++
               "    uint32_t ret = (uint32_t)0;\n" ++
               "\n" ++
@@ -96,7 +96,7 @@ spec = do
               "\n" ++
               "    } else {\n" ++
               "\n" ++
-              "        ret = *((uint32_t *)option0.__Some.__0.datum);\n" ++
+              "        ret = *((uint32_t *)option0.__Some.__0.data);\n" ++
               "\n" ++
               "    }\n" ++
               "\n" ++
@@ -105,10 +105,10 @@ spec = do
               "}\n")
     it "Prints declaration of function match_test1" $ do
       renderHeader test1 `shouldBe`
-        pack "uint32_t match_test1(__Option_dyn_t option0);\n"
+        pack "uint32_t match_test1(__termina_option_dyn_t option0);\n"
     it "Prints definition of function match_test1" $ do
       renderSource test1 `shouldBe`
-        pack ("uint32_t match_test1(__Option_dyn_t option0) {\n" ++
+        pack ("uint32_t match_test1(__termina_option_dyn_t option0) {\n" ++
               "    \n" ++
               "    uint32_t ret = (uint32_t)0;\n" ++
               "\n" ++
@@ -117,7 +117,7 @@ spec = do
               "        \n" ++
               "    } else {\n" ++
               "\n" ++
-              "        ret = *((uint32_t *)option0.__Some.__0.datum);\n" ++
+              "        ret = *((uint32_t *)option0.__Some.__0.data);\n" ++
               "\n" ++
               "    }\n" ++
               "\n" ++

--- a/test/UT/PPrinter/Expression/ArithmeticSpec.hs
+++ b/test/UT/PPrinter/Expression/ArithmeticSpec.hs
@@ -73,19 +73,19 @@ spec = do
         pack "var0 + (uint16_t)1024"
     it "Prints the expression: var1 + 1024 : u16" $ do
       renderExpression var1PlusConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) + (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) + (uint16_t)1024"
     it "Prints the expression: 1024 : u16 + var0" $ do
       renderExpression constantPlusVar0 `shouldBe`
         pack "(uint16_t)1024 + var0"
     it "Prints the expression: 1024 : u16 + var1" $ do
       renderExpression constantPlusVar1 `shouldBe`
-        pack "(uint16_t)1024 + *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 + *((uint16_t *)var1.data)"
     it "Prints the expression: var0 + var1 : u16" $ do
       renderExpression var0PlusVar1 `shouldBe`
-        pack "var0 + *((uint16_t *)var1.datum)"
+        pack "var0 + *((uint16_t *)var1.data)"
     it "Prints the expression: var0 + var1 + 1024 : u16" $ do
       renderExpression var0PlusVar1PlusConstant `shouldBe`
-        pack "(uint16_t)(var0 + *((uint16_t *)var1.datum)) + (uint16_t)1024"
+        pack "(uint16_t)(var0 + *((uint16_t *)var1.data)) + (uint16_t)1024"
     it "Prints the expression: var0 - 1024 : u16" $ do
       renderExpression var0MinusConstant `shouldBe`
         pack "var0 - (uint16_t)1024"
@@ -100,11 +100,11 @@ spec = do
         pack "(uint16_t)1024 * var0"
     it "Prints the expression: var0 * var1 : u16" $ do
       renderExpression var0MultVar1 `shouldBe`
-        pack "var0 * *((uint16_t *)var1.datum)"
+        pack "var0 * *((uint16_t *)var1.data)"
     it "Prints the expression: var1 / 1024 : u16" $ do
       renderExpression var1Divconstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) / (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) / (uint16_t)1024"
     it "Prints the expression: var0 / var1 : u16" $ do
       renderExpression var0DivVar1 `shouldBe`
-        pack "var0 / *((uint16_t *)var1.datum)"
+        pack "var0 / *((uint16_t *)var1.data)"
 

--- a/test/UT/PPrinter/Expression/BitwiseSpec.hs
+++ b/test/UT/PPrinter/Expression/BitwiseSpec.hs
@@ -76,19 +76,19 @@ spec = do
         pack "var0 << (uint8_t)8"
     it "Prints the expression: var1 << 8 : u8" $ do
       renderExpression var1LeftShiftConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) << (uint8_t)8"
+        pack "*((uint16_t *)var1.data) << (uint8_t)8"
     it "Prints the expression: 8 : u8 << var0" $ do
       renderExpression constantLeftShiftVar0 `shouldBe`
         pack "(uint8_t)8 << var0"
     it "Prints the expression: 8 : u8 << var1" $ do
       renderExpression constantLeftShiftVar1 `shouldBe`
-        pack "(uint8_t)8 << *((uint16_t *)var1.datum)"
+        pack "(uint8_t)8 << *((uint16_t *)var1.data)"
     it "Prints the expression: var0 << var1 : u16" $ do
       renderExpression var0LeftShiftVar1 `shouldBe`
-        pack "var0 << *((uint16_t *)var1.datum)"
+        pack "var0 << *((uint16_t *)var1.data)"
     it "Prints the expression: var0 << var1 << 8 : u8" $ do
       renderExpression var0LeftShiftVar1LeftShiftConstant `shouldBe`
-        pack "(uint16_t)(var0 << *((uint16_t *)var1.datum)) << (uint8_t)8"
+        pack "(uint16_t)(var0 << *((uint16_t *)var1.data)) << (uint8_t)8"
     it "Prints the expression: var0 >> 8 : u8" $ do
       renderExpression var0RightShiftConstant `shouldBe`
         pack "var0 >> (uint8_t)8"
@@ -103,18 +103,18 @@ spec = do
         pack "(uint16_t)1024 & var0"
     it "Prints the expression: var0 & var1 : u16" $ do
       renderExpression var0BitwiseAndVar1 `shouldBe`
-        pack "var0 & *((uint16_t *)var1.datum)"
+        pack "var0 & *((uint16_t *)var1.data)"
     it "Prints the expression: var1 | 1024 : u16" $ do
       renderExpression var1BitwiseOrconstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) | (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) | (uint16_t)1024"
     it "Prints the expression: var0 | var1 : u16" $ do
       renderExpression var0BitwiseOrVar1 `shouldBe`
-        pack "var0 | *((uint16_t *)var1.datum)"
+        pack "var0 | *((uint16_t *)var1.data)"
     it "Prints the expression: var1 ^ 1024 : u16" $ do
       renderExpression var1BitwiseXorconstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) ^ (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) ^ (uint16_t)1024"
     it "Prints the expression: var0 ^ var1 : u16" $ do
       renderExpression var0BitwiseXorVar1 `shouldBe`
-        pack "var0 ^ *((uint16_t *)var1.datum)"
+        pack "var0 ^ *((uint16_t *)var1.data)"
         
     

--- a/test/UT/PPrinter/Expression/FunctionCallSpec.hs
+++ b/test/UT/PPrinter/Expression/FunctionCallSpec.hs
@@ -133,7 +133,7 @@ spec = do
         pack "foo(&var0)"
     it "Prints the expression: foo(&var1)" $ do
       renderExpression functionCallSingleRefDynVar1 `shouldBe`
-        pack "foo((uint16_t *)var1.datum)"
+        pack "foo((uint16_t *)var1.data)"
     it "Prints the expression: foo(*p_var)" $ do
       renderExpression functionCallSingleDerefpVar `shouldBe`
         pack "foo(*(p_var))"
@@ -142,19 +142,19 @@ spec = do
         pack "foo(var0 + (uint16_t)1024)"
     it "Prints the expression: foo(var1 + 1024 : u16)" $ do
       renderExpression functionCallSingleDynVar1PlusConstant `shouldBe`
-        pack "foo(*((uint16_t *)var1.datum) + (uint16_t)1024)"
+        pack "foo(*((uint16_t *)var1.data) + (uint16_t)1024)"
     it "Prints the expression: foo(var0 + dynVar1)" $ do
       renderExpression functionCallSingleVar0PlusVar1 `shouldBe`
-        pack "foo(var0 + *((uint16_t *)var1.datum))"
+        pack "foo(var0 + *((uint16_t *)var1.data))"
     it "Prints the expression: foo(*p_var + 1024 : u16)" $ do
       renderExpression functionCallSingleDerefpVarPlusConstant `shouldBe`
         pack "foo(*(p_var) + (uint16_t)1024)"
     it "Prints the expression: foo(*p_var + *p_dynVar3)" $ do
       renderExpression functionCallSingleDerefpVarPlusDerefRefVar1 `shouldBe`
-        pack "foo(*(p_var) + *((uint16_t *)var1.datum))"
+        pack "foo(*(p_var) + *((uint16_t *)var1.data))"
     it "Prints the expression: foo(vector0)" $ do
       renderExpression functionCallSingleVector0 `shouldBe`
-        pack "foo(*((__param__foo__param0_t *)vector0))"
+        pack "foo(*((__param_foo_param0_t *)vector0))"
     it "Prints the expression: foo(&vector0)" $ do
       renderExpression functionCallSingleRefVector0 `shouldBe`
         pack "foo(vector0)"
@@ -167,17 +167,17 @@ spec = do
   describe "Pretty printing function call expressions with multiple parameters" $ do
     it "Prints the expression: foo2(var0 + (uint16_t)1024, var0 + var1)" $ do
       renderExpression call2Parameters `shouldBe`
-        pack "foo2(var0 + (uint16_t)1024, var0 + *((uint16_t *)var1.datum))"
+        pack "foo2(var0 + (uint16_t)1024, var0 + *((uint16_t *)var1.data))"
     it "Prints the expression: foo3(vector0, &var0, var1 + 1024 : u16)" $ do
       renderExpression call3Parameters `shouldBe`
-        pack ("foo3(&var0, *((__param__foo3__param1_t *)vector0),\n" ++
-              "     *((uint16_t *)var1.datum) + (uint16_t)1024)")
+        pack ("foo3(&var0, *((__param_foo3_param1_t *)vector0),\n" ++
+              "     *((uint16_t *)var1.data) + (uint16_t)1024)")
     it "Prints the expression: foo4(dynVector0, &dynVar1, foo(var0), foo2(var0 + (uint16_t)1024, var0 + dynVar1))" $ do
       renderExpression call4Parameters `shouldBe`
         pack (
-          "foo4(dynVector0, (uint16_t *)var1.datum, foo(var0),\n" ++
-          "     foo2(var0 + (uint16_t)1024, var0 + *((uint16_t *)var1.datum)))")
+          "foo4(dynVector0, (uint16_t *)var1.data, foo(var0),\n" ++
+          "     foo2(var0 + (uint16_t)1024, var0 + *((uint16_t *)var1.data)))")
   describe "Pretty printing functions returning and receiving arrays" $ do
     it "Prints the expression foo() with a function returning an array" $ do
       renderExpression functionCallRetArray `shouldBe`
-        pack "foo()"
+        pack "foo().array"

--- a/test/UT/PPrinter/Expression/MemberAccessSpec.hs
+++ b/test/UT/PPrinter/Expression/MemberAccessSpec.hs
@@ -31,4 +31,4 @@ spec = do
         pack "tm_descriptor0.field0"
     it "Prints the expression: tm_descriptor1.field0" $ do
       renderExpression tmDescriptor1field0 `shouldBe`
-        pack "*((TMDescriptor *)tm_descriptor1.datum).field0"
+        pack "*((TMDescriptor *)tm_descriptor1.data).field0"

--- a/test/UT/PPrinter/Expression/MemberMethodAccessSpec.hs
+++ b/test/UT/PPrinter/Expression/MemberMethodAccessSpec.hs
@@ -31,10 +31,10 @@ spec = do
   describe "Pretty printing method call expressions" $ do
     it "Prints the expression: tm_pool.alloc()" $ do
       renderExpression tmPoolAlloc `shouldBe`
-        pack "__pool_alloc(&tm_pool)"
+        pack "__termina_pool_alloc(&tm_pool)"
     it "Prints the expression: tm_channel.foo0(bar0)" $ do
       renderExpression tmChannelsend `shouldBe`
-        pack "__msg_queue_send(&tm_channel, bar0)"
+        pack "__termina_msg_queue_send(&tm_channel, bar0)"
     it "Prints the expression: resource.foo0(bar0, bar1)" $ do
       renderExpression resource0foo0 `shouldBe`
         pack "__Resource_foo0(&resource0, bar0, bar1)"

--- a/test/UT/PPrinter/Expression/ReferenceSpec.hs
+++ b/test/UT/PPrinter/Expression/ReferenceSpec.hs
@@ -66,13 +66,13 @@ spec = do
         pack "vector1"
     it "Prints the expression: &dyn_var0" $ do
       renderExpression refDynVar0expr `shouldBe`
-        pack "(uint16_t *)dyn_var0.datum"
+        pack "(uint16_t *)dyn_var0.data"
     it "Prints the expression: &dyn_vector0" $ do
       renderExpression refDynVector0expr `shouldBe`
-        pack "(uint32_t *)dyn_vector0.datum"
+        pack "(uint32_t *)dyn_vector0.data"
     it "Prints the expression: &dyn_vector1" $ do
       renderExpression refDynVector1expr `shouldBe`
-        pack "(int64_t (*)[5])dyn_vector1.datum"
+        pack "(int64_t (*)[5])dyn_vector1.data"
   describe "Pretty printing dereference expressions" $ do
     it "Prints the expression: *p_var0" $ do
       renderExpression derefpVar0 `shouldBe`

--- a/test/UT/PPrinter/Expression/RelationalSpec.hs
+++ b/test/UT/PPrinter/Expression/RelationalSpec.hs
@@ -90,123 +90,123 @@ spec = do
         pack "var0 == (uint16_t)1024"
     it "Prints the expression: var1 == 1024 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var1EqConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) == (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) == (uint16_t)1024"
     it "Prints the expression: 1024 : u16 == var0" $ do
       renderExpression constantEqVar0 `shouldBe`
         pack "(uint16_t)1024 == var0"
     it "Prints the expression: 1024 : u16 == var1 (var1 : 'dyn u16)" $ do
       renderExpression constantEqVar1 `shouldBe`
-        pack "(uint16_t)1024 == *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 == *((uint16_t *)var1.data)"
     it "Prints the expression: var0 == var1 (var1 : 'dyn u16)" $ do
       renderExpression var0EqVar1 `shouldBe`
-        pack "var0 == *((uint16_t *)var1.datum)"
+        pack "var0 == *((uint16_t *)var1.data)"
   describe "Pretty printing not-equality expressions" $ do
     it "Prints the expression: var0 != 1024 : u16" $ do
       renderExpression var0NeqConstant `shouldBe`
         pack "var0 != (uint16_t)1024"
     it "Prints the expression: var1 != 1024 : u16" $ do
       renderExpression var1NeqConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) != (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) != (uint16_t)1024"
     it "Prints the expression: 1024 : u16 != var0" $ do
       renderExpression constantNeqVar0 `shouldBe`
         pack "(uint16_t)1024 != var0"
     it "Prints the expression: 1024 : u16 != var1" $ do
       renderExpression constantNeqVar1 `shouldBe`
-        pack "(uint16_t)1024 != *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 != *((uint16_t *)var1.data)"
     it "Prints the expression: var0 != var1 : u16" $ do
       renderExpression var0NeqVar1 `shouldBe`
-        pack "var0 != *((uint16_t *)var1.datum)"
+        pack "var0 != *((uint16_t *)var1.data)"
   describe "Pretty printing greater than expressions" $ do
     it "Prints the expression: var0 > 1024 : u16" $ do
       renderExpression var0GTConstant `shouldBe`
         pack "var0 > (uint16_t)1024"
     it "Prints the expression: var1 > 1024 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var1GTConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) > (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) > (uint16_t)1024"
     it "Prints the expression: 1024 : u16 > var0" $ do
       renderExpression constantGTVar0 `shouldBe`
         pack "(uint16_t)1024 > var0"
     it "Prints the expression: 1024 : u16 > var1 (var1 : 'dyn u16)" $ do
       renderExpression constantGTVar1 `shouldBe`
-        pack "(uint16_t)1024 > *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 > *((uint16_t *)var1.data)"
     it "Prints the expression: var0 > var1 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var0GTVar1 `shouldBe`
-        pack "var0 > *((uint16_t *)var1.datum)"
+        pack "var0 > *((uint16_t *)var1.data)"
   describe "Pretty printing greater than or equal expressions" $ do
     it "Prints the expression: var0 >= 1024 : u16" $ do
       renderExpression var0GTEConstant `shouldBe`
         pack "var0 >= (uint16_t)1024"
     it "Prints the expression: var1 >= 1024 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var1GTEConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) >= (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) >= (uint16_t)1024"
     it "Prints the expression: 1024 : u16 >= var0" $ do
       renderExpression constantGTEVar0 `shouldBe`
         pack "(uint16_t)1024 >= var0"
     it "Prints the expression: 1024 : u16 >= var1 (var1 : 'dyn u16)" $ do
       renderExpression constantGTEVar1 `shouldBe`
-        pack "(uint16_t)1024 >= *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 >= *((uint16_t *)var1.data)"
     it "Prints the expression: var0 >= var1 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var0GTEVar1 `shouldBe`
-        pack "var0 >= *((uint16_t *)var1.datum)"
+        pack "var0 >= *((uint16_t *)var1.data)"
   describe "Pretty printing less than expressions" $ do
     it "Prints the expression: var0 < 1024 : u16" $ do
       renderExpression var0LTConstant `shouldBe`
         pack "var0 < (uint16_t)1024"
     it "Prints the expression: var1 < 1024 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var1LTConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) < (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) < (uint16_t)1024"
     it "Prints the expression: 1024 : u16 < var0" $ do
       renderExpression constantLTVar0 `shouldBe`
         pack "(uint16_t)1024 < var0"
     it "Prints the expression: 1024 : u16 < var1 (var1 : 'dyn u16)" $ do
       renderExpression constantLTVar1 `shouldBe`
-        pack "(uint16_t)1024 < *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 < *((uint16_t *)var1.data)"
     it "Prints the expression: var0 < var1 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var0LTVar1 `shouldBe`
-        pack "var0 < *((uint16_t *)var1.datum)"
+        pack "var0 < *((uint16_t *)var1.data)"
   describe "Pretty printing less than expressions" $ do
     it "Prints the expression: var0 < 1024 : u16" $ do
       renderExpression var0LTConstant `shouldBe`
         pack "var0 < (uint16_t)1024"
     it "Prints the expression: var1 < 1024 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var1LTConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) < (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) < (uint16_t)1024"
     it "Prints the expression: 1024 : u16 < var0" $ do
       renderExpression constantLTVar0 `shouldBe`
         pack "(uint16_t)1024 < var0"
     it "Prints the expression: 1024 : u16 < var1 (var1 : 'dyn u16)" $ do
       renderExpression constantLTVar1 `shouldBe`
-        pack "(uint16_t)1024 < *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 < *((uint16_t *)var1.data)"
     it "Prints the expression: var0 < var1 : u16 (var1 : 'dyn u16)" $ do
       renderExpression var0LTVar1 `shouldBe`
-        pack "var0 < *((uint16_t *)var1.datum)"
+        pack "var0 < *((uint16_t *)var1.data)"
   describe "Pretty printing less than or equal expressions" $ do
     it "Prints the expression: var0 <= 1024 : u16" $ do
       renderExpression var0LTEConstant `shouldBe`
         pack "var0 <= (uint16_t)1024"
     it "Prints the expression: var1 <= 1024 : u16" $ do
       renderExpression var1LTEConstant `shouldBe`
-        pack "*((uint16_t *)var1.datum) <= (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) <= (uint16_t)1024"
     it "Prints the expression: 1024 : u16 <= var0" $ do
       renderExpression constantLTEVar0 `shouldBe`
         pack "(uint16_t)1024 <= var0"
     it "Prints the expression: 1024 : u16 <= var1" $ do
       renderExpression constantLTEVar1 `shouldBe`
-        pack "(uint16_t)1024 <= *((uint16_t *)var1.datum)"
+        pack "(uint16_t)1024 <= *((uint16_t *)var1.data)"
     it "Prints the expression: var0 <= var1 : u16" $ do
       renderExpression var0LTEVar1 `shouldBe`
-        pack "var0 <= *((uint16_t *)var1.datum)"
+        pack "var0 <= *((uint16_t *)var1.data)"
   describe "Pretty printing logical and expressions" $ do
     it "Prints the expression: true && false" $ do
       renderExpression logicalAndConst `shouldBe`
         pack "1 && 0"
     it "Prints the expression: var0 == var1 && var4 != var5" $ do
       renderExpression logicalAndExpr `shouldBe`
-        pack "var0 == *((uint16_t *)var1.datum) && var0 <= (uint16_t)1024"
+        pack "var0 == *((uint16_t *)var1.data) && var0 <= (uint16_t)1024"
   describe "Pretty printing logical or expressions" $ do
     it "Prints the expression: false || true" $ do
       renderExpression logicalOrConst `shouldBe`
         pack "0 || 1"
     it "Prints the expression: var1 < 1024 || var2 == var3" $ do
       renderExpression logicalOrExpr `shouldBe`
-        pack "*((uint16_t *)var1.datum) < (uint16_t)1024 || var0 <= (uint16_t)1024"
+        pack "*((uint16_t *)var1.data) < (uint16_t)1024 || var0 <= (uint16_t)1024"

--- a/test/UT/PPrinter/Expression/VariableSpec.hs
+++ b/test/UT/PPrinter/Expression/VariableSpec.hs
@@ -51,19 +51,19 @@ spec = do
         pack "dyn_var0"
     it "Prints the undyned variable dyn_var0 : 'dyn u16" $ do
       renderExpression (AccessObject ( (Undyn dynVar0 uint16SemAnn))) `shouldBe`
-        pack "*((uint16_t *)dyn_var0.datum)"
+        pack "*((uint16_t *)dyn_var0.data)"
     it "Prints the variable dyn_vector0 : 'dyn [u32; 10 : u32] between parenthesis" $ do
       renderExpression (ParensExpression (AccessObject ( dynVector0)) dynVectorAnn) `shouldBe`
         pack "(dyn_vector0)"
     it "Prints the undyned variable dyn_vector0 : 'dyn [u32; 10 : u32] between parenthesis" $ do
       renderExpression (ParensExpression (AccessObject ( (Undyn dynVector0 vectorAnn))) vectorAnn) `shouldBe`
-        pack "(((uint32_t *)dyn_vector0.datum))"
+        pack "(((uint32_t *)dyn_vector0.data))"
     it "Prints the variable dyn_vector1 : 'dyn [[i64; 5 : u32]; 10 : u32]" $ do
       renderExpression (AccessObject ( dynVector1)) `shouldBe`
         pack "dyn_vector1"
     it "Prints the undyned variable dyn_vector1 : 'dyn [[i64; 5 : u32]; 10 : u32]" $ do
       renderExpression (AccessObject ( (Undyn dynVector1 twoDymVectorAnn))) `shouldBe`
-        pack "((int64_t (*)[5])dyn_vector1.datum)"
+        pack "((int64_t (*)[5])dyn_vector1.data)"
     it "Prints the undyned variable dyn_vector2 : [[[char; 40 : u32]; 5 : u32]; 10 : u32]" $ do
       renderExpression (AccessObject ( (Undyn dynVector2 dynThreeDymVectorAnn))) `shouldBe`
-        pack "((char (*)[5][40])dyn_vector2.datum)"
+        pack "((char (*)[5][40])dyn_vector2.data)"

--- a/test/UT/PPrinter/Expression/VectorIndexSpec.hs
+++ b/test/UT/PPrinter/Expression/VectorIndexSpec.hs
@@ -71,10 +71,10 @@ spec = do
         pack "vector1[(uint32_t)3][(uint32_t)4]"
     it "Prints the expression: dyn_vector0[0x08 : u8]" $ do
       renderExpression dynVector0IndexConstant `shouldBe`
-        pack "((uint32_t *)dyn_vector0.datum)[(uint8_t)8]"
+        pack "((uint32_t *)dyn_vector0.data)[(uint8_t)8]"
     it "Prints the expression: dyn_vector0[var0]" $ do
       renderExpression dynVector0IndexVar0 `shouldBe`
-        pack "((uint32_t *)dyn_vector0.datum)[var0]"
+        pack "((uint32_t *)dyn_vector0.data)[var0]"
     it "Prints the expression: *vector0[3 : u32]" $ do
       renderExpression derefpVector0IndexConstant `shouldBe`
         pack "p_vector0[(uint32_t)3]"

--- a/test/UT/PPrinter/FunctionSpec.hs
+++ b/test/UT/PPrinter/FunctionSpec.hs
@@ -156,9 +156,9 @@ spec = do
       renderFunctionDeclaration function3 `shouldBe`
         pack ("typedef struct {\n" ++
               "    uint32_t array[10];\n" ++
-              "} __param__function3__param1_t;\n" ++
+              "} __param_function3_param1_t;\n" ++
               "\n" ++
-              "uint32_t function3(uint32_t param0, __param__function3__param1_t param1);\n")
+              "uint32_t function3(uint32_t param0, __param_function3_param1_t param1);\n")
     it "Prints fuction4 declaration" $ do
       renderFunctionDeclaration function4 `shouldBe`
         pack "uint32_t function4(uint32_t param0, uint32_t param1[10]);\n"
@@ -231,7 +231,7 @@ spec = do
               "}\n")
     it "Prints fuction3 definition" $ do
       renderFunction function3 `shouldBe`
-        pack ("uint32_t function3(uint32_t param0, __param__function3__param1_t param1) {\n" ++
+        pack ("uint32_t function3(uint32_t param0, __param_function3_param1_t param1) {\n" ++
               "    \n" ++
               "    TMDescriptor struct0;\n" ++
               "\n" ++

--- a/test/UT/PPrinter/Statement/AssignmentSpec.hs
+++ b/test/UT/PPrinter/Statement/AssignmentSpec.hs
@@ -224,7 +224,7 @@ spec = do
   describe "Pretty printing undyn assignments" $ do
     it "Prints the statement dyn_var0 = foo1" $ do
       renderStatement undynVar0AssignFoo1 `shouldBe`
-        pack "*((uint32_t *)dyn_var0.datum) = foo1;"
+        pack "*((uint32_t *)dyn_var0.data) = foo1;"
     it "Prints the statement dyn_var0 = 1024 : u32" $ do
       renderStatement undynVar0AssignConst `shouldBe`
-        pack "*((uint32_t *)dyn_var0.datum) = (uint32_t)1024;"
+        pack "*((uint32_t *)dyn_var0.data) = (uint32_t)1024;"

--- a/test/UT/PPrinter/Statement/FreeSpec.hs
+++ b/test/UT/PPrinter/Statement/FreeSpec.hs
@@ -1,0 +1,34 @@
+module UT.PPrinter.Statement.FreeSpec (spec) where
+
+import Test.Hspec
+import PPrinter
+import SemanAST
+import Data.Text hiding (empty)
+import Data.Map
+import Semantic.Monad
+import PPrinter.Statement
+import UT.PPrinter.Expression.Common
+
+dynVectorAnn :: SemanticAnns
+dynVectorAnn = dynVectorSemAnn UInt32 (I UInt32 10)
+
+dynVar0, dynVector0 :: Object SemanticAnns
+dynVar0 = Variable "dyn_var0" dynUInt32SemAnn
+dynVector0 = Variable "dyn_vector0" dynVectorAnn
+
+freeVar0, freeVector0 :: Statement SemanticAnns
+freeVar0 = Free dynVar0 undefined
+freeVector0 = Free dynVector0 undefined
+
+renderStatement :: Statement SemanticAnns -> Text
+renderStatement = render . ppStatement empty
+
+spec :: Spec
+spec = do
+  describe "Pretty printing free statements" $ do
+    it "Prints the statement free(dyn_var0);" $ do
+      renderStatement freeVar0 `shouldBe`
+        pack "__termina_pool_free(dyn_var0);"
+    it "Prints the statement free(dyn_vector0);" $ do
+      renderStatement freeVector0 `shouldBe`
+        pack "__termina_pool_free(dyn_vector0);"

--- a/test/UT/PPrinter/Statement/IfElseSpec.hs
+++ b/test/UT/PPrinter/Statement/IfElseSpec.hs
@@ -88,7 +88,7 @@ spec = do
           "        }\n" ++
           "    }\n" ++
           "\n" ++
-          "    __Option_dyn_t option0;\n" ++
+          "    __termina_option_dyn_t option0;\n" ++
           "\n" ++
           "    {\n" ++
           "        option0.__variant = Some;\n" ++
@@ -109,7 +109,7 @@ spec = do
           "        }\n" ++
           "    }\n" ++
           "\n" ++
-          "    __Option_dyn_t option0;\n" ++
+          "    __termina_option_dyn_t option0;\n" ++
           "\n" ++
           "    {\n" ++
           "        option0.__variant = Some;\n" ++
@@ -118,7 +118,7 @@ spec = do
           "\n" ++
           "} else {\n" ++
           "\n" ++
-          "    __Option_dyn_t option1;\n" ++
+          "    __termina_option_dyn_t option1;\n" ++
           "\n" ++
           "    {\n" ++
           "        option1.__variant = None;\n" ++
@@ -138,7 +138,7 @@ spec = do
           "        }\n" ++
           "    }\n" ++
           "\n" ++
-          "    __Option_dyn_t option0;\n" ++
+          "    __termina_option_dyn_t option0;\n" ++
           "\n" ++
           "    {\n" ++
           "        option0.__variant = Some;\n" ++
@@ -151,7 +151,7 @@ spec = do
           "\n" ++
           "} else {\n" ++
           "\n" ++
-          "    __Option_dyn_t option1;\n" ++
+          "    __termina_option_dyn_t option1;\n" ++
           "\n" ++
           "    {\n" ++
           "        option1.__variant = None;\n" ++

--- a/test/UT/PPrinter/Statement/MatchSpec.hs
+++ b/test/UT/PPrinter/Statement/MatchSpec.hs
@@ -8,7 +8,6 @@ import Data.Map
 import Semantic.Monad
 import PPrinter.Statement
 import UT.PPrinter.Expression.Common
-import Semantic.Types
 
 optionDynUInt32SemAnn :: SemanticAnns
 optionDynUInt32SemAnn = optionDynSemAnn UInt32
@@ -84,7 +83,7 @@ spec = do
         pack (
           "if (option_var.__variant == Some) {\n" ++
           "\n" ++
-          "    foo1 = *((uint32_t *)option_var.__Some.__0.datum);\n" ++
+          "    foo1 = *((uint32_t *)option_var.__Some.__0.data);\n" ++
           "\n" ++
           "} else {\n" ++
           "\n" ++
@@ -100,18 +99,18 @@ spec = do
           "\n" ++
           "} else {\n" ++
           "\n" ++
-          "    foo1 = ((uint32_t *)option_var.__Some.__0.datum)[(uint8_t)8];\n" ++
+          "    foo1 = ((uint32_t *)option_var.__Some.__0.data)[(uint8_t)8];\n" ++
           "\n" ++
           "}")
     it "Prints a match option statement with a complex expression" $ do
       renderStatement matchOption2 `shouldBe`
         pack (
           "{\n" ++
-          "    __Option_dyn_t __match = get_integer();\n" ++
+          "    __termina_option_dyn_t __match = get_integer();\n" ++
           "\n" ++
           "    if (__match.__variant == Some) {\n" ++
           "\n" ++
-          "        foo1 = *((uint32_t *)__match.__Some.__0.datum);\n" ++
+          "        foo1 = *((uint32_t *)__match.__Some.__0.data);\n" ++
           "\n" ++
           "    } else {\n" ++
           "\n" ++

--- a/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
+++ b/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
@@ -103,7 +103,7 @@ spec = do
     it "Prints the statement var option0 : Option <'dyn u32> = Some(dyn_var0);" $ do
       renderStatement option0 `shouldBe`
         pack (
-          "__Option_dyn_t option0;\n" ++
+          "__termina_option_dyn_t option0;\n" ++
           "\n" ++
           "{\n" ++
           "    option0.__variant = Some;\n" ++
@@ -112,7 +112,7 @@ spec = do
     it "Prints the statement var option1 : Option <'dyn u32> = None;" $ do
       renderStatement option1 `shouldBe`
         pack (
-          "__Option_dyn_t option1;\n" ++
+          "__termina_option_dyn_t option1;\n" ++
           "\n" ++
           "{\n" ++
           "    option1.__variant = None;\n" ++

--- a/test/UT/PPrinter/TypeDef/ClassSpec.hs
+++ b/test/UT/PPrinter/TypeDef/ClassSpec.hs
@@ -111,7 +111,7 @@ spec = do
           "    uint32_t __dummy;\n" ++
           "} id0;\n" ++
           "\n" ++
-          "void __id0_method0(uint8_t param0, __Option_dyn_t param1);\n" ++
+          "void __id0_method0(uint8_t param0, __termina_option_dyn_t param1);\n" ++
           "\n" ++
           "void __id0_method1(uint8_t param0, uint8_t param1[32]);\n")
     it "Prints a class marked as no_handler with one method and zero fields" $ do


### PR DESCRIPTION
This commit applies the following changes:

- Homogenization of the name of functions calling the Termina runtime. Now, all functions are prefixed with `__termina_`.  All the necessary changes have been made to the tests. All tests pass.
- Fixed support for functions that return and receive arrays as parameters.  There were small bugs in code generation that have been fixed. A new integration test has been defined to test the changes. All tests pass.
- Minor changes in the code of the printer functions.

The code generator for class methods and global volatile objects still needs to be completed.