### PR TITLE
Added new operation to create array slice

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -33,6 +33,11 @@ data Object a
   | ParensObject (Object a) a
   -- ^ Object in parenthesis | (eI) |. This operation is needed to be able to
   -- use references to vectors as objects: (*vector)[i].
+  | VectorSliceExpression (Object a) ConstExpression ConstExpression a
+  -- ^ Array slicing | eI [ cEx .. cEy ]|,
+  -- value |eI :: exprI a| is an identifier expression
+  -- |cEx| is an expression for the lower bound
+  -- |cEx| is an expression for the upper bound
   deriving (Show, Functor)
 
 instance Annotated Object where
@@ -41,6 +46,7 @@ instance Annotated Object where
   getAnnotation (MemberAccess _ _ a)          = a
   getAnnotation (Dereference _ a)             = a
   getAnnotation (ParensObject _ a)            = a
+  getAnnotation (VectorSliceExpression _ _ _ a) = a
 
 ----------------------------------------
 

--- a/src/PPrinter/Common.hs
+++ b/src/PPrinter/Common.hs
@@ -9,12 +9,14 @@ import           Semantic.Monad
 type DocStyle = Doc AnsiStyle
 
 getObjectType :: Object SemanticAnns -> TypeSpecifier
-getObjectType (Variable _ (SemAnn _ (ETy (SimpleType ts))))   = ts
-getObjectType (VectorIndexExpression _ _ (SemAnn _ (ETy (SimpleType ts)))) = ts
-getObjectType (MemberAccess _ _ (SemAnn _ (ETy (SimpleType ts))))          = ts
-getObjectType (Dereference _ (SemAnn _ (ETy (SimpleType ts))))             = ts
-getObjectType (Undyn _ (SemAnn _ (ETy (SimpleType ts))))                   = ts
-getObjectType _ = error "invalid object annotation"
+getObjectType (Variable _ (SemAnn _ (ETy (SimpleType ts))))                  = ts
+getObjectType (VectorIndexExpression _ _ (SemAnn _ (ETy (SimpleType ts))))   = ts
+getObjectType (MemberAccess _ _ (SemAnn _ (ETy (SimpleType ts))))            = ts
+getObjectType (Dereference _ (SemAnn _ (ETy (SimpleType ts))))               = ts
+getObjectType (VectorSliceExpression _ _ _ (SemAnn _ (ETy (SimpleType ts)))) = ts
+getObjectType (Undyn _ (SemAnn _ (ETy (SimpleType ts))))                     = ts
+getObjectType (ParensObject _ (SemAnn _ (ETy (SimpleType ts))))              = ts
+getObjectType obj = error $ "invalid object annotation: " ++ show obj
 
 getType :: Expression SemanticAnns -> TypeSpecifier
 getType (AccessObject obj) = getObjectType obj

--- a/src/SemanAST.hs
+++ b/src/SemanAST.hs
@@ -26,6 +26,11 @@ data Object a
   | ParensObject (Object a) a
   -- ^ Object in parenthesis | (eI) |. This operation is needed to be able to
   -- use references to vectors as objects: (*vector)[i].
+  | VectorSliceExpression (Object a) ConstExpression ConstExpression a
+  -- ^ Array slicing | eI [ cEx .. cEy ]|,
+  -- value |eI :: exprI a| is an identifier expression
+  -- |cEx| is an expression for the lower bound
+  -- |cEx| is an expression for the upper bound
   | Undyn (Object a) a
   deriving (Show, Functor)
 
@@ -35,6 +40,7 @@ instance Annotated Object where
   getAnnotation (MemberAccess _ _ a)          = a
   getAnnotation (Dereference _ a)             = a
   getAnnotation (ParensObject _ a)            = a
+  getAnnotation (VectorSliceExpression _ _ _ a) = a
   getAnnotation (Undyn _ a)                   = a
 ----------------------------------------
 

--- a/src/Semantic/Errors.hs
+++ b/src/Semantic/Errors.hs
@@ -174,6 +174,13 @@ data Errors a
   | EMsgQueueSendArgNotDyn TypeSpecifier
   | EMsgQueueWrongType TypeSpecifier TypeSpecifier
   | EMsgQueueRcvWrongArgTy TypeSpecifier
+  -- | Vector slicing
+  | ELowerBoundConst ConstExpression -- | Lower bound is not a numeric constant expression
+  | EUpperBoundConst ConstExpression -- | Upper bound is not a numeric constant expression
+  | EBoundsTypeMismatch TypeSpecifier TypeSpecifier -- | Lower and upper bounds are not of the same type
+  | EBoundsAndVectorTypeMismatch TypeSpecifier TypeSpecifier -- | Bounds are not of the same type as the vector
+  | EBoundsLowerGTUpper Integer Integer -- | Lower bound is greater than upper bound
+  | EUpperBoundGTSize Integer Integer -- | Upper bound is greater than the size of the vector
   deriving Show
 
 instance Eq (Errors a) where

--- a/test/IT/Expression/VectorSliceSpec.hs
+++ b/test/IT/Expression/VectorSliceSpec.hs
@@ -1,0 +1,173 @@
+module IT.Expression.VectorSliceSpec (spec) where
+
+import Test.Hspec
+import PPrinter
+import Data.Text hiding (empty)
+import Parsing
+import Semantic.TypeChecking
+import Text.Parsec
+
+test0 :: String
+test0 = "fn slice_test0() {\n" ++
+        "    var vector0 : [u32; 10 : u32] = [0 : u32; 10 : u32];\n" ++
+        "    vector0[3 : u32..10 : u32][1 : u32] = 10 : u32;\n" ++
+        "    return;\n" ++
+        "}"
+
+test1 :: String
+test1 = "fn slice_test1(vector0 : & [[[u32; 3 : u32]; 5 : u32]; 10 : u32]) {\n" ++
+        "    (*vector0)[3 : u32 .. 8 : u32] = [[[10 : u32; 3 : u32]; 5 : u32]; 5 : u32];\n" ++
+        "    return;\n" ++
+        "}"
+
+test2 :: String
+test2 = "fn add_one(input : & [u32; 5 : u32]) {\n" ++ 
+        "    for i in 0 : u32 .. 5 : u32 {\n" ++
+        "        (*input)[i] = (*input)[i] + 1 : u32;\n" ++
+        "    }\n" ++
+        "    return;\n" ++
+        "}\n" ++
+        "\n" ++
+        "fn slice_test2(vector0 : & [[u32; 5 : u32]; 10 : u32]) {\n" ++
+        "    add_one(&(*vector0)[2 : u32 .. 3 : u32][0 : u32]);\n" ++
+        "    return;\n" ++
+        "}"
+
+test3 :: String
+test3 = "fn add_two(input : [u32; 5 : u32]) {\n" ++ 
+        "    for i in 0 : u32 .. 5 : u32 {\n" ++
+        "        input[i] = input[i] + 2 : u32;\n" ++
+        "    }\n" ++
+        "    return;\n" ++
+        "}\n" ++
+        "\n" ++
+        "fn slice_test3(vector0 : & [[u32; 5 : u32]; 10 : u32]) {\n" ++
+        "    add_two((*vector0)[2 : u32 .. 3 : u32][0 : u32]);\n" ++
+        "    return;\n" ++
+        "}"
+
+renderHeader :: String -> Text
+renderHeader input = case parse (contents topLevel) "" input of
+  Left err -> error $ "Parser Error: " ++ show err
+  Right ast -> 
+    case typeCheckRun ast of
+      Left err -> pack $ "Type error: " ++ show err
+      Right tast -> ppHeaderFile tast
+
+renderSource :: String -> Text
+renderSource input = case parse (contents topLevel) "" input of
+  Left err -> error $ "Parser Error: " ++ show err
+  Right ast -> 
+    case typeCheckRun ast of
+      Left err -> pack $ "Type error: " ++ show err
+      Right tast -> ppSourceFile tast
+
+spec :: Spec
+spec = do
+  describe "Pretty printing vector slicing expressions" $ do
+    it "Prints declaration of function slice_test0" $ do
+      renderHeader test0 `shouldBe`
+        pack "void slice_test0();\n"
+    it "Prints definition of function slice_test0" $ do
+      renderSource test0 `shouldBe`
+        pack ("void slice_test0() {\n" ++
+              "    \n" ++
+              "    uint32_t vector0[10];\n" ++
+              "\n" ++
+              "    {\n" ++
+              "        for (uint32_t __i0 = 0; __i0 < (uint32_t)10; __i0 = __i0 + (uint32_t)1) {\n" ++
+              "            vector0[__i0] = (uint32_t)0;\n" ++
+              "        }\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    (&vector0[(uint32_t)3])[(uint32_t)1] = (uint32_t)10;\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n")    
+    it "Prints declaration of function slice_test1" $ do
+      renderHeader test1 `shouldBe`
+        pack "void slice_test1(uint32_t vector0[10][5][3]);\n"
+    it "Prints definition of function slice_test0" $ do
+      renderSource test1 `shouldBe`
+        pack ("void slice_test1(uint32_t vector0[10][5][3]) {\n" ++
+              "    \n" ++
+              "    {\n" ++
+              "        for (uint32_t __i0 = 0; __i0 < (uint32_t)5; __i0 = __i0 + (uint32_t)1) {\n" ++
+              "            for (uint32_t __i1 = 0; __i1 < (uint32_t)5; __i1 = __i1 + (uint32_t)1) {\n" ++
+              "                for (uint32_t __i2 = 0; __i2 < (uint32_t)3; __i2 = __i2 + (uint32_t)1) {\n" ++
+              "                    (&(vector0)[(uint32_t)3])[__i0][__i1][__i2] = (uint32_t)10;\n" ++
+              "                }\n" ++
+              "            }\n" ++
+              "        }\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n") 
+    it "Prints declaration of function slice_test2" $ do
+      renderHeader test2 `shouldBe`
+        pack ("void add_one(uint32_t input[5]);\n" ++
+              "\n" ++
+              "void slice_test2(uint32_t vector0[10][5]);\n")
+    it "Prints definition of function slice_test2" $ do
+      renderSource test2 `shouldBe`
+        pack ("void add_one(uint32_t input[5]) {\n" ++
+              "    \n" ++
+              "    {\n" ++
+              "        uint32_t __start = (uint32_t)0;\n" ++
+              "        uint32_t __end = (uint32_t)5;\n" ++
+              "\n" ++
+              "        for (uint32_t i = __start; i < __end; i = i + (uint32_t)1) {\n" ++
+              "            \n" ++
+              "            (input)[i] = (input)[i] + (uint32_t)1;\n" ++
+              "\n" ++
+              "        }\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n" ++
+              "\n" ++
+              "void slice_test2(uint32_t vector0[10][5]) {\n" ++
+              "    \n" ++
+              "    add_one((&(vector0)[(uint32_t)2])[(uint32_t)0]);\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n")
+    it "Prints declaration of function slice_test3" $ do
+      renderHeader test3 `shouldBe`
+        pack ("typedef struct {\n" ++
+              "    uint32_t array[5];\n" ++
+              "} __param_add_two_input_t;\n" ++
+              "\n" ++
+              "void add_two(__param_add_two_input_t input);\n" ++
+              "\n" ++
+              "void slice_test3(uint32_t vector0[10][5]);\n")
+    it "Prints definition of function slice_test3" $ do
+      renderSource test3 `shouldBe`
+        pack ("void add_two(__param_add_two_input_t input) {\n" ++
+              "    \n" ++
+              "    {\n" ++
+              "        uint32_t __start = (uint32_t)0;\n" ++
+              "        uint32_t __end = (uint32_t)5;\n" ++
+              "\n" ++
+              "        for (uint32_t i = __start; i < __end; i = i + (uint32_t)1) {\n" ++
+              "            \n" ++
+              "            input.array[i] = input.array[i] + (uint32_t)2;\n" ++
+              "\n" ++
+              "        }\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n" ++
+              "\n" ++
+              "void slice_test3(uint32_t vector0[10][5]) {\n" ++
+              "    \n" ++
+              "    add_two(*((__param_add_two_input_t *)((&(vector0)[(uint32_t)2])[(uint32_t)0])));\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n") 

--- a/test/UT/PPrinter/Expression/Common.hs
+++ b/test/UT/PPrinter/Expression/Common.hs
@@ -2,7 +2,6 @@ module UT.PPrinter.Expression.Common where
 
 import SemanAST
 import Semantic.Monad
-import Semantic.Types
 
 tySemAnn :: TypeSpecifier -> SemanticAnns
 tySemAnn ts = SemAnn undefined (ETy (SimpleType ts))


### PR DESCRIPTION
This new operation allows to select a subset of consecutive elements of an array. For example, if we have the following array:

```
var foo : [u32; 10 : u32] = [0; 10 : u32];
```
The expression:
```
foo[1 : u32 .. 5 : u32] = [1 : u32; 4 : u32];
```
writes a value of 1 to elements `foo[1]` to `foo[4]`, inclusive.

The parser and type checker have been modified accordingly. New integration tests have been defined for these expressions. All tests pass.