### PR TITLE
Some more changes

### DIFF
--- a/src/AST/Core.hs
+++ b/src/AST/Core.hs
@@ -104,7 +104,10 @@ data TypeSpecifier
   | Pool TypeSpecifier Size
   | Reference AccessKind TypeSpecifier
   | DynamicSubtype TypeSpecifier
+  -- | Fixed-location types
   | Location TypeSpecifier
+  -- | Port types
+  | Port TypeSpecifier
   -- See Q9
   | Unit
   deriving (Show)
@@ -205,8 +208,7 @@ data ClassMember' expr obj a
   = 
     -- | Fields. They form the state  of the object
     ClassField 
-      Identifier -- ^ name of the field
-      TypeSpecifier -- ^ type of the field
+      FieldDefinition -- ^ the field
       a -- ^ transpiler annotation
     -- | Methods. Methods are internal functions that can privately access the state of the
     -- object and call other methods of the same class.
@@ -221,8 +223,7 @@ data ClassMember' expr obj a
     | ClassProcedure
       Identifier -- ^ name of the procedure
       [Parameter] -- ^ list of parameters (possibly empty)
-      (Maybe TypeSpecifier) -- ^ type of the return value (optional)
-      (BlockRet' expr obj a) -- ^ statements block (with return) a
+      (Block' expr obj a) -- ^ statements block (with return) a
       a -- ^ transpiler annotation
     | ClassViewer
       Identifier -- ^ name of the procedure
@@ -251,6 +252,7 @@ data Parameter = Parameter {
 data FieldAssignment' expr a =
   FieldValueAssignment Identifier (expr a)
   | FieldAddressAssignment Identifier Address
+  | FieldPortConnection Identifier Identifier
   deriving (Show, Functor)
 
 data FieldDefinition = FieldDefinition {

--- a/src/PPrinter.hs
+++ b/src/PPrinter.hs
@@ -34,6 +34,7 @@ ppHeaderASTElement _ = Nothing
 ppSourceASTElement :: AnnASTElement SemanticAnns -> Maybe DocStyle
 ppSourceASTElement (TypeDefinition (Struct {}) _) = Nothing
 ppSourceASTElement (TypeDefinition (Enum {}) _) = Nothing
+ppSourceASTElement (TypeDefinition cls@(Class {}) _) = Just (ppClassDefinition cls)
 ppSourceASTElement func@(Function {}) = Just (ppFunction func)
 ppSourceASTElement _ = Nothing
 

--- a/src/PPrinter/Function.hs
+++ b/src/PPrinter/Function.hs
@@ -6,20 +6,6 @@ import AST.Seman
 import PPrinter.Common
 import Semantic.Monad (SemanticAnns)
 import PPrinter.Statement
-import PPrinter.Expression (Substitutions)
-import Data.Map
-
-ppBlockRet :: Substitutions -> DocStyle -> BlockRet SemanticAnns -> DocStyle
-ppBlockRet subs identifier (BlockRet body ret) =
-  braces' (
-    indentTab . align $
-      line <> vsep [ppStatement subs s <> line | s <- body]
-      <> line <> ppReturnStmt identifier ret <> line
-  ) <> line
-
-ppParameterSubstitutions :: [Parameter] -> Substitutions
-ppParameterSubstitutions parameters =
-  fromList [(pid, pretty pid <> pretty ".array") | (Parameter pid (Vector {})) <- parameters]
 
 ppFunction :: AnnASTElement SemanticAnns -> DocStyle
 ppFunction (Function identifier parameters rTS blk _ _) =

--- a/src/PPrinter/Statement/VariableInitialization.hs
+++ b/src/PPrinter/Statement/VariableInitialization.hs
@@ -114,7 +114,7 @@ ppInitializeStruct subs level target expr =
     (FieldAssignmentsExpression _ vas _) ->
         vsep $
             map (\(FieldValueAssignment field expr') -> ppFieldInitializer subs level target (pretty field) expr') vas
-    _ -> error "Incorrect expression"
+    _ -> error $ "Incorrect initialization expression: " ++ show expr
 
 ppInitializeEnum ::
   Substitutions ->

--- a/src/Semantic/Errors.hs
+++ b/src/Semantic/Errors.hs
@@ -26,6 +26,10 @@ data Errors a
   | EReferenceGlobal Identifier
   -- | Not Variable found
   | ENotVar
+  -- | Invalid access to global object
+  | EInvalidAccessToGlobal Identifier
+  -- | Invalid writing access to read only object
+  | EObjectIsReadOnly Identifier
   | ENotNamedObject Identifier
   -- | Not Global Variable found
   | ENotNamedGlobal Identifier
@@ -53,17 +57,22 @@ data Errors a
   | EFieldMissing [Identifier]
   -- | Record extra fields
   | EFieldExtra [Identifier]
+  -- | Field is not a fixed location
+  | EFieldNotFixedLocation Identifier
   -- | Field does not have a fixed location
-  | EFieldAddress Identifier
+  | EFieldNotPort Identifier
   -- | Expecting a Vecotor got
   | EVector TypeSpecifier
   -- | Expecting a Enumeration when memberAccessing got
   | EMemberAccess TypeSpecifier
   | EFunctionAccessNotResource TypeSpecifier
   | EMemberAccessNotMember Identifier -- TODO: We can return the list of identifiers.
-  | EMemberAccessNotMethod Identifier
+  -- | Calling a procedure within another member function
+  | EMemberAccessInvalidProcedureCall Identifier
+  | EMemberAccessNotProcedure Identifier
+  | EMemberAccessNotFunction Identifier
   | EMemberAccessUDef (SemanTypeDef a)
-  | EMemberMethodUDef (SemanTypeDef a)
+  | EMemberFunctionUDef (SemanTypeDef a)
   | EMemberMethodType
   | EMemberMethodExtraParams
   | EMemberMethodMissingParams
@@ -109,6 +118,8 @@ data Errors a
   -- | ENoPrimitiveType TypeSpecifier
   -- | Only option Dyn
   | EOptionDyn TypeSpecifier
+  -- | Port specifier not a shared resource
+  | EPortNotResource TypeSpecifier
   -- | Dynamic a non primitive type
   | EDynPrim TypeSpecifier
   -- | Function Declaration error,
@@ -117,6 +128,8 @@ data Errors a
   | EUnboxingObjectExpr
   -- | Expected Simple Type
   | EExpectedSimple TypeSpecifier
+  -- | Invalid class field type
+  | EInvalidClassFieldType TypeSpecifier
   -- | Forbidden Reference Type
   | EReferenceTy TypeSpecifier
   -- | Complex expression on LHS

--- a/src/Semantic/Types.hs
+++ b/src/Semantic/Types.hs
@@ -54,11 +54,11 @@ type SemanClassMember = ClassMember' K SAST.Object
 
 -- Forgetfull Class member map
 kClassMember :: ClassMember' exp lhs a -> ClassMember' K lhs a
-kClassMember (ClassField idx tyx a) = ClassField idx tyx a
+kClassMember (ClassField fld a) = ClassField fld a
 kClassMember (ClassMethod idx ps _blk ann) =
   ClassMethod idx ps (BlockRet [] (ReturnStmt Nothing (returnAnnotation (blockRet _blk)))) ann
-kClassMember (ClassProcedure idx ps ty _blk ann) =
-  ClassProcedure idx ps ty (BlockRet [] (ReturnStmt Nothing (returnAnnotation (blockRet _blk)))) ann
+kClassMember (ClassProcedure idx ps _blk ann) =
+  ClassProcedure idx ps [] ann
 kClassMember (ClassViewer idx ps ty _blk ann) =
   ClassViewer idx ps ty (BlockRet [] (ReturnStmt Nothing (returnAnnotation (blockRet _blk)))) ann
 

--- a/src/Utils/AST/Core.hs
+++ b/src/Utils/AST/Core.hs
@@ -12,12 +12,12 @@ findClassField i
   (\case {ClassMethod {} -> error "Impossible after find"
          ; ClassProcedure {} -> error "Impossible after find"
          ; ClassViewer {} -> error "Impossible after find"
-         ; ClassField _ t a -> (t, a)})
+         ; ClassField (FieldDefinition _ t) a -> (t, a)})
   .
   L.find (\case { ClassMethod {} -> False
                 ; ClassProcedure {} -> False
                 ; ClassViewer {} -> False
-                ; ClassField ident _ _ -> ident == i
+                ; ClassField (FieldDefinition ident _) _ -> ident == i
                 ;})
 
 findClassProcedure :: Identifier -> [ ClassMember' expr lho a ] -> Maybe ([Parameter], a)
@@ -26,38 +26,24 @@ findClassProcedure i
   (\case {ClassField {} -> error "Impossible after find"
          ; ClassMethod {} -> error "Impossible after find"
          ; ClassViewer {} -> error "Impossible after find"
-         ; ClassProcedure _ ps _ _ a -> (ps,a)}
+         ; ClassProcedure _ ps _ a -> (ps,a)}
          )
   .
   L.find (\case{ClassField {} -> False
                ; ClassMethod {} -> False
                ; ClassViewer {} -> False
-               ; ClassProcedure ident _ _ _ _ -> (ident == i)})
+               ; ClassProcedure ident _ _ _ -> (ident == i)})
 
-findClassViewer :: Identifier -> [ ClassMember' expr lho a ] -> Maybe ([Parameter], TypeSpecifier, a)
-findClassViewer i
+findClassViewerOrMethod :: Identifier -> [ ClassMember' expr lho a ] -> Maybe ([Parameter], Maybe TypeSpecifier, a)
+findClassViewerOrMethod i
   = fmap
   (\case {ClassField {} -> error "Impossible after find"
-         ; ClassMethod {} -> error "Impossible after find"
+         ; ClassMethod _ mty _ a  -> ([], mty, a)
          ; ClassProcedure {} -> error "Impossible after find"
-         ;  ClassViewer _ ps ty _ a -> (ps, ty, a)}
+         ;  ClassViewer _ ps ty _ a -> (ps, Just ty, a)}
          )
   .
   L.find (\case{ClassField {} -> False
                ; ClassMethod {} -> False
                ; ClassProcedure {} -> False
                ; ClassViewer ident _ _ _ _ -> (ident == i)})
-
-findClassMethod :: Identifier -> [ ClassMember' expr lho a ] -> Maybe (Maybe TypeSpecifier, a)
-findClassMethod i
-  = fmap
-  (\case {ClassField {} -> error "Impossible after find"
-         ; ClassViewer {} -> error "Impossible after find"
-         ; ClassProcedure {} -> error "Impossible after find"
-         ; ClassMethod _ ty _ a -> (ty, a)}
-         )
-  .
-  L.find (\case{ClassField {} -> False
-               ; ClassViewer {} -> False
-               ; ClassProcedure {} -> False
-               ; ClassMethod ident _ _ _ -> (ident == i)})

--- a/src/Utils/TypeSpecifier.hs
+++ b/src/Utils/TypeSpecifier.hs
@@ -30,7 +30,17 @@ simpleType (DynamicSubtype {}) = False
 simpleType (MsgQueue {})       = False
 simpleType (Pool {})           = False
 simpleType (Reference {})      = False
+simpleType (Location {})       = False
+simpleType (Port {})           = False
 simpleType _                   = True
+
+classFieldType :: TypeSpecifier -> Bool
+classFieldType Unit                = False
+classFieldType (DynamicSubtype {}) = False
+classFieldType (MsgQueue {})       = False
+classFieldType (Pool {})           = False
+classFieldType (Reference {})      = False
+classFieldType _                   = True
 
 boolTy :: TypeSpecifier -> Bool
 boolTy Bool = True

--- a/test/IT/Expression/ArithmeticSpec.hs
+++ b/test/IT/Expression/ArithmeticSpec.hs
@@ -59,7 +59,7 @@ spec = do
     it "Prints definition of function test0" $ do
       renderSource test0 `shouldBe`
         pack ("void test0() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint16_t foo = 0;\n" ++ 
               "\n" ++
               "    foo = foo + 1024;\n" ++
@@ -87,7 +87,7 @@ spec = do
     it "Prints definition of function test1" $ do
      renderSource test1 `shouldBe`
        pack ("void test1(__termina_dyn_t foo) {\n" ++
-             "    \n" ++
+             "\n" ++
              "    *((uint16_t *)foo.data) = *((uint16_t *)foo.data) + 1024;\n" ++
              "\n" ++
              "    1024 + *((uint16_t *)foo.data);\n" ++

--- a/test/IT/Expression/BitwiseSpec.hs
+++ b/test/IT/Expression/BitwiseSpec.hs
@@ -48,7 +48,7 @@ spec = do
     it "Prints definition of function bitwise_test0" $ do
       renderSource test0 `shouldBe`
         pack ("void bitwise_test0(uint16_t foo) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint8_t bar = 0;\n" ++ 
               "\n" ++
               "    foo = foo << 8;\n" ++

--- a/test/IT/Expression/CastSpec.hs
+++ b/test/IT/Expression/CastSpec.hs
@@ -48,7 +48,7 @@ spec = do
     it "Prints definition of function bitwise_test0" $ do
       renderSource test0 `shouldBe`
         pack ("void casting_test0() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint8_t bar_u8 = 0;\n" ++
               "\n" ++
               "    uint16_t bar_u16 = 0;\n" ++

--- a/test/IT/Expression/FunctionCallSpec.hs
+++ b/test/IT/Expression/FunctionCallSpec.hs
@@ -8,22 +8,22 @@ import Text.Parsec
 import Semantic.TypeChecking
 
 test0 :: String
-test0 = "function func_test0_0(a : u16) : u16 {\n" ++
+test0 = "function func_test0_0(a : u16) -> u16 {\n" ++
         "    return (a + (1 : u16));\n" ++
         "}\n" ++
         "\n" ++
-        "function func_test0_1(a : u16) : u16 {\n" ++
+        "function func_test0_1(a : u16) -> u16 {\n" ++
         "    var foo : u16 = func_test0_0(2 : u16);\n" ++
         "    return (foo * (2 : u16));\n" ++
         "}"
 
 test1 :: String
-test1 = "function func_test1_0() : [u32; 10 : u32] {\n" ++
+test1 = "function func_test1_0() -> [u32; 10 : u32] {\n" ++
         "    var foo : [u32; 10 : u32] = [1024 : u32; 10 : u32];\n" ++
         "    return foo;\n" ++
         "}\n" ++
         "\n" ++
-        "function func_test1_1() : u32 {\n" ++
+        "function func_test1_1() -> u32 {\n" ++
         "    var bar0 : [u32; 10 : u32] = [0 : u32; 10 : u32];\n" ++
         "    bar0 = func_test1_0();\n" ++
         "    var bar1 : [u32; 10 : u32] = func_test1_0();\n" ++
@@ -56,14 +56,13 @@ spec = do
     it "Prints definition of functions of test0" $ do
       renderSource test0 `shouldBe`
         pack ("uint16_t func_test0_0(uint16_t a) {\n" ++
-              "    \n" ++
               "\n" ++
               "    return a + 1;\n" ++
               "\n" ++
               "}\n" ++
               "\n" ++
               "uint16_t func_test0_1(uint16_t a) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint16_t foo = func_test0_0(2);\n" ++
               "\n" ++
               "    return foo * 2;\n" ++
@@ -81,7 +80,7 @@ spec = do
     it "Prints definition of functions test0 and test1" $ do
       renderSource test1 `shouldBe`
         pack ("__ret_func_test1_0_t func_test1_0() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t foo[10];\n" ++
               "\n" ++
               "    {\n" ++
@@ -95,7 +94,7 @@ spec = do
               "}\n" ++
               "\n" ++
               "uint32_t func_test1_1() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t bar0[10];\n" ++
               "\n" ++
               "    {\n" ++

--- a/test/IT/Expression/RelationalSpec.hs
+++ b/test/IT/Expression/RelationalSpec.hs
@@ -51,7 +51,7 @@ spec = do
     it "Prints definition of function bitwise_test0" $ do
       renderSource test0 `shouldBe`
         pack ("void relational_test0(uint16_t foo) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    _Bool res = 0;\n" ++
               "\n" ++
               "    res = foo == 1024;\n" ++

--- a/test/IT/Expression/VectorIndexSpec.hs
+++ b/test/IT/Expression/VectorIndexSpec.hs
@@ -51,7 +51,7 @@ spec = do
     it "Prints definition of function vector_test0" $ do
       renderSource test0 `shouldBe`
         pack ("void vector_test0() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t foo = 0;\n" ++
               "\n" ++
               "    uint32_t vector0[10];\n" ++
@@ -87,7 +87,7 @@ spec = do
     it "Prints definition of function vector_test1" $ do
       renderSource test1 `shouldBe`
         pack ("void vector_test1(uint32_t p_vector0[10]) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t foo = 0;\n" ++
               "\n" ++
               "    p_vector0[3] = 10;\n" ++

--- a/test/IT/Expression/VectorSliceSpec.hs
+++ b/test/IT/Expression/VectorSliceSpec.hs
@@ -71,7 +71,7 @@ spec = do
     it "Prints definition of function slice_test0" $ do
       renderSource test0 `shouldBe`
         pack ("void slice_test0() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t vector0[10];\n" ++
               "\n" ++
               "    {\n" ++
@@ -91,7 +91,7 @@ spec = do
     it "Prints definition of function slice_test0" $ do
       renderSource test1 `shouldBe`
         pack ("void slice_test1(uint32_t vector0[10][5][3]) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    {\n" ++
               "        for (uint32_t __i0 = 0; __i0 < 5; __i0 = __i0 + 1) {\n" ++
               "            for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
@@ -113,7 +113,7 @@ spec = do
     it "Prints definition of function slice_test2" $ do
       renderSource test2 `shouldBe`
         pack ("void add_one(uint32_t input[5]) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    {\n" ++
               "        uint32_t __start = 0;\n" ++
               "        uint32_t __end = 5;\n" ++
@@ -130,7 +130,7 @@ spec = do
               "}\n" ++
               "\n" ++
               "void slice_test2(uint32_t vector0[10][5]) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    add_one((&vector0[2])[0]);\n" ++
               "\n" ++
               "    return;\n" ++
@@ -148,7 +148,7 @@ spec = do
     it "Prints definition of function slice_test3" $ do
       renderSource test3 `shouldBe`
         pack ("void add_two(__param_add_two_input_t input) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    {\n" ++
               "        uint32_t __start = 0;\n" ++
               "        uint32_t __end = 5;\n" ++
@@ -165,7 +165,7 @@ spec = do
               "}\n" ++
               "\n" ++
               "void slice_test3(uint32_t vector0[10][5]) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    add_two(*((__param_add_two_input_t *)(&vector0[2])[0]));\n" ++
               "\n" ++
               "    return;\n" ++

--- a/test/IT/Global/PoolSpec.hs
+++ b/test/IT/Global/PoolSpec.hs
@@ -15,21 +15,7 @@ test0 = "enum Message {\n" ++
         "    Reset\n" ++
         "};\n" ++
         "\n" ++
-        "resource message_pool : Pool<Message; 10>;\n" ++
-        "\n" ++
-        "function test0(in0 : u32, in1 : u32) {\n" ++
-        "    var alloc_msg : Option<dyn Message> = None;\n" ++
-        "    message_pool.alloc(&alloc_msg);\n" ++
-        "    match alloc_msg {\n" ++
-        "        case Some(msg) => {\n" ++
-        "            msg = Message::In(in0, in1);\n" ++
-        "            free(msg);\n" ++
-        "        }\n" ++
-        "        case None => {\n" ++
-        "        }\n" ++
-        "    }\n" ++
-        "    return;\n" ++
-        "}"
+        "resource message_pool : Pool<Message; 10>;\n"
 
 renderHeader :: String -> Text
 renderHeader input = case parse (contents topLevel) "" input of
@@ -39,18 +25,10 @@ renderHeader input = case parse (contents topLevel) "" input of
       Left err -> pack $ "Type error: " ++ show err
       Right tast -> ppHeaderFile tast
 
-renderSource :: String -> Text
-renderSource input = case parse (contents topLevel) "" input of
-  Left err -> error $ "Parser Error: " ++ show err
-  Right ast -> 
-    case typeCheckRun ast of
-      Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppSourceFile tast
-
 spec :: Spec
 spec = do
   describe "Pretty printing pool methods" $ do
-    it "Prints declaration of function test0" $ do
+    it "Prints declaration of Message type and external pool" $ do
       renderHeader test0 `shouldBe`
         pack ("typedef enum {\n" ++
               "    In,\n" ++
@@ -75,36 +53,4 @@ spec = do
               "\n" ++
               "} Message;\n" ++
               "\n" ++
-              "extern __termina_pool_t message_pool;\n" ++
-              "\n" ++
-              "void test0(uint32_t in0, uint32_t in1);\n")
-    it "Prints definition of functions test0" $ do
-      renderSource test0 `shouldBe`
-        pack ("void test0(uint32_t in0, uint32_t in1) {\n" ++
-              "    \n" ++
-              "    __termina_option_dyn_t alloc_msg;\n" ++
-              "\n" ++
-              "    {\n" ++
-              "        alloc_msg.__variant = None;\n" ++
-              "    }\n" ++
-              "\n" ++
-              "    __termina_pool_alloc(&message_pool, &alloc_msg);\n" ++
-              "\n" ++
-              "    if (alloc_msg.__variant == None) {\n" ++
-              "\n" ++
-              "        \n" ++
-              "    } else {\n" ++
-              "\n" ++
-              "        {\n" ++
-              "            *((Message *)alloc_msg.__Some.__0.data).__variant = In;\n" ++
-              "            *((Message *)alloc_msg.__Some.__0.data).__In.__0 = in0;\n" ++
-              "            *((Message *)alloc_msg.__Some.__0.data).__In.__1 = in1;\n" ++
-              "        }\n" ++
-              "\n" ++
-              "        __termina_pool_free(alloc_msg.__Some.__0);\n" ++
-              "\n" ++
-              "    }\n" ++
-              "\n" ++
-              "    return;\n" ++
-              "\n" ++
-              "}\n")    
+              "extern __termina_pool_t message_pool;\n")

--- a/test/IT/Statement/AssignmentSpec.hs
+++ b/test/IT/Statement/AssignmentSpec.hs
@@ -65,7 +65,7 @@ spec = do
     it "Prints definition of function assignment_test0" $ do
       renderSource test0 `shouldBe`
         pack ("void assignment_test0() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t foo0 = 0;\n" ++
               "\n" ++
               "    uint32_t foo1 = 0;\n" ++
@@ -81,7 +81,7 @@ spec = do
     it "Prints definition of function assignment_test1" $ do
      renderSource test1 `shouldBe`
         pack ("void assignment_test1(__termina_dyn_t dyn_var0) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    __termina_option_dyn_t option;\n" ++
               "\n" ++
               "    {\n" ++
@@ -102,7 +102,7 @@ spec = do
     it "Prints definition of function assignment_test2" $ do
      renderSource test2 `shouldBe`
         pack ("void assignment_test2(__termina_dyn_t dyn_var0, __termina_dyn_t dyn_var1) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t foo = 0;\n" ++
               "\n" ++
               "    *((uint32_t *)dyn_var0.data) = foo;\n" ++
@@ -120,7 +120,7 @@ spec = do
     it "Prints definition of function assignment_test2" $ do
      renderSource test3 `shouldBe`
         pack ("void assignment_test3(__termina_dyn_t dyn_var0, __termina_dyn_t dyn_var1) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t foo[10];\n" ++
               "\n" ++
               "    {\n" ++

--- a/test/IT/Statement/ForLoopSpec.hs
+++ b/test/IT/Statement/ForLoopSpec.hs
@@ -8,7 +8,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 
 test0 :: String
-test0 = "function for_loop_test0(array0 : [u16; 10 : u32]) : u16 {\n" ++
+test0 = "function for_loop_test0(array0 : [u16; 10 : u32]) -> u16 {\n" ++
         "    var total : u16 = 0 : u16;\n" ++
         "    for i : u32 in 0 : u32 .. 10 : u32 {\n" ++
         "        total = total + array0[i];\n" ++  
@@ -17,7 +17,7 @@ test0 = "function for_loop_test0(array0 : [u16; 10 : u32]) : u16 {\n" ++
         "}"
 
 test1 :: String
-test1 = "function for_loop_test1(array0 : & [u16; 10 : u32]) : bool {\n" ++
+test1 = "function for_loop_test1(array0 : & [u16; 10 : u32]) -> bool {\n" ++
         "    var found : bool = false;\n" ++
         "    for i : u32 in 0 : u32 .. 10 : u32 while found == false {\n" ++
         "        if (*array0)[i] == 1024 : u16 {\n" ++
@@ -56,7 +56,7 @@ spec = do
     it "Prints definition of function for_loop_test0_test0" $ do
       renderSource test0 `shouldBe`
         pack ("uint16_t for_loop_test0(__param_for_loop_test0_array0_t array0) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint16_t total = 0;\n" ++
               "\n" ++
               "    {\n" ++
@@ -79,7 +79,7 @@ spec = do
     it "Prints definition of function assignment_test1" $ do
       renderSource test1 `shouldBe`
         pack ("_Bool for_loop_test1(uint16_t array0[10]) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    _Bool found = 0;\n" ++
               "\n" ++
               "    {\n" ++

--- a/test/IT/Statement/MatchSpec.hs
+++ b/test/IT/Statement/MatchSpec.hs
@@ -8,7 +8,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 
 test0 :: String
-test0 = "function match_test0(option0 : Option<dyn u32>) : u32 {\n" ++
+test0 = "function match_test0(option0 : Option<dyn u32>) -> u32 {\n" ++
         "    var ret : u32 = 0 : u32;\n" ++
         "    match option0 {\n" ++
         "        case Some(value) => {\n" ++
@@ -22,7 +22,7 @@ test0 = "function match_test0(option0 : Option<dyn u32>) : u32 {\n" ++
         "}"
 
 test1 :: String
-test1 = "function match_test1(option0 : Option<dyn u32>) : u32 {\n" ++
+test1 = "function match_test1(option0 : Option<dyn u32>) -> u32 {\n" ++
         "    var ret : u32 = 0 : u32;\n" ++
         "    match option0 {\n" ++
         "        case None => {\n" ++
@@ -42,7 +42,7 @@ test2 = "enum Message {\n" ++
         "    Reset\n" ++
         "};\n" ++
         "\n" ++
-        "function match_test1() : u32 {\n" ++
+        "function match_test1() -> u32 {\n" ++
         "    var ret : u32 = 0 : u32;\n" ++
         "    var msg : Message = Message::In(10 : u32, 10 : u32);\n" ++
         "    match msg {\n" ++
@@ -87,7 +87,7 @@ spec = do
     it "Prints definition of function match_test0" $ do
       renderSource test0 `shouldBe`
         pack ("uint32_t match_test0(__termina_option_dyn_t option0) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t ret = 0;\n" ++
               "\n" ++
               "    if (option0.__variant == None) {\n" ++
@@ -109,7 +109,7 @@ spec = do
     it "Prints definition of function match_test1" $ do
       renderSource test1 `shouldBe`
         pack ("uint32_t match_test1(__termina_option_dyn_t option0) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t ret = 0;\n" ++
               "\n" ++
               "    if (option0.__variant == None) {\n" ++
@@ -153,7 +153,7 @@ spec = do
     it "Prints definition of function match_test1" $ do
       renderSource test2 `shouldBe`
         pack ("uint32_t match_test1() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    uint32_t ret = 0;\n" ++
               "\n    Message msg;\n" ++
               "\n" ++

--- a/test/IT/TypeDef/ResourceSpec.hs
+++ b/test/IT/TypeDef/ResourceSpec.hs
@@ -1,0 +1,92 @@
+module IT.TypeDef.ResourceSpec (spec) where
+
+import Test.Hspec
+import Parser.Parsing
+import PPrinter
+import Data.Text hiding (empty)
+import Text.Parsec
+import Semantic.TypeChecking
+
+test0 :: String
+test0 = "resource class TMChannel {\n" ++
+        "  tm_sent_packets : u32;\n" ++
+        "\n" ++
+        "  procedure get_tm_sent_packets(&priv self, packets : &mut u32) {\n" ++
+        "    *packets = self->tm_sent_packets;\n" ++
+        "    return;\n" ++
+        "  }\n" ++
+        "\n" ++
+        "};\n"
+
+test1 :: String
+test1 = "resource class UARTDriver {\n" ++
+        "  status : loc u32;\n" ++
+        "\n" ++
+        "  procedure get_status(&priv self, ret : &mut u32) {\n" ++
+        "    *ret = self->status;\n" ++
+        "    return;\n" ++
+        "  }\n" ++
+        "\n" ++
+        "};\n"
+
+renderHeader :: String -> Text
+renderHeader input = case parse (contents topLevel) "" input of
+  Left err -> error $ "Parser Error: " ++ show err
+  Right ast -> 
+    case typeCheckRun ast of
+      Left err -> pack $ "Type error: " ++ show err
+      Right tast -> ppHeaderFile tast
+
+renderSource :: String -> Text
+renderSource input = case parse (contents topLevel) "" input of
+  Left err -> error $ "Parser Error: " ++ show err
+  Right ast -> 
+    case typeCheckRun ast of
+      Left err -> pack $ "Type error: " ++ show err
+      Right tast -> ppSourceFile tast
+
+spec :: Spec
+spec = do
+  describe "Pretty printing class methods" $ do
+    it "Prints declaration of class TMChannel without no_handler" $ do
+      renderHeader test0 `shouldBe`
+        pack ("typedef struct {\n" ++
+              "    uint32_t tm_sent_packets;\n" ++
+              "    __termina_resource_id_t __resource_id;\n" ++
+              "} TMChannel;\n" ++
+              "\n" ++
+              "void __TMChannel_get_tm_sent_packets(TMChannel * self, uint32_t * packets);\n")
+    it "Prints definition of class TMChannel without no_handler" $ do
+      renderSource test0 `shouldBe`
+        pack ("void __TMChannel_get_tm_sent_packets(TMChannel * self, uint32_t * packets) {\n" ++
+              "\n" ++
+              "    __termina_resource_lock(self->__resource_id);\n" ++
+              "\n" ++
+              "    *packets = self->tm_sent_packets;\n" ++
+              "\n" ++
+              "    __termina_resource_unlock(self->__resource_id);\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n")
+    it "Prints declaration of class UARTDriver" $ do
+      renderHeader test1 `shouldBe`
+        pack ("typedef struct {\n" ++
+              "    volatile uint32_t * status;\n" ++
+              "    __termina_resource_id_t __resource_id;\n" ++
+              "} UARTDriver;\n" ++
+              "\n" ++
+              "void __UARTDriver_get_status(UARTDriver * self, uint32_t * ret);\n")
+    it "Prints definition of class UARTDriver" $ do
+      renderSource test1 `shouldBe`
+        pack ("void __UARTDriver_get_status(UARTDriver * self, uint32_t * ret) {\n" ++
+              "\n" ++
+              "    __termina_resource_lock(self->__resource_id);\n" ++
+              "\n" ++
+              "    *ret = *self->status;\n" ++
+              "\n" ++
+              "    __termina_resource_unlock(self->__resource_id);\n" ++
+              "\n" ++
+              "    return;\n" ++
+              "\n" ++
+              "}\n")

--- a/test/IT/TypeDef/TaskSpec.hs
+++ b/test/IT/TypeDef/TaskSpec.hs
@@ -1,0 +1,125 @@
+module IT.TypeDef.TaskSpec (spec) where
+
+import Test.Hspec
+import Parser.Parsing
+import PPrinter
+import Data.Text hiding (empty)
+import Text.Parsec
+import Semantic.TypeChecking
+
+test0 :: String
+test0 = "enum Message {\n" ++
+        "    In (u32, u32),\n" ++
+        "    Out (u32),\n" ++
+        "    Stop,\n" ++
+        "    Reset\n" ++
+        "};\n" ++
+        "\n" ++
+        "task class CHousekeeping {\n" ++
+        "  interval : u32;\n" ++
+        "  message_pool : port Pool<Message; 10>;\n" ++
+        "\n" ++
+        "  method run(&priv self) -> TaskRet {\n" ++
+        "\n" ++        
+        "    var ret : TaskRet = TaskRet::Continue;\n" ++
+        "\n" ++
+        "    self->interval = self->interval + 1 : u32;\n" ++
+        "\n" ++
+        "    var alloc_msg : Option<dyn Message> = None;\n" ++
+        "    self->message_pool.alloc(&mut alloc_msg);\n" ++
+        "    match alloc_msg {\n" ++
+        "        case Some(msg) => {\n" ++
+        "            free(msg);\n" ++
+        "        }\n" ++
+        "        case None => {\n" ++
+        "        }\n" ++
+        "    }\n" ++
+        "\n" ++
+        "    return ret;\n" ++
+        "  }\n" ++
+        "\n" ++
+        "};\n"
+
+renderHeader :: String -> Text
+renderHeader input = case parse (contents topLevel) "" input of
+  Left err -> error $ "Parser Error: " ++ show err
+  Right ast -> 
+    case typeCheckRun ast of
+      Left err -> pack $ "Type error: " ++ show err
+      Right tast -> ppHeaderFile tast
+
+renderSource :: String -> Text
+renderSource input = case parse (contents topLevel) "" input of
+  Left err -> error $ "Parser Error: " ++ show err
+  Right ast -> 
+    case typeCheckRun ast of
+      Left err -> pack $ "Type error: " ++ show err
+      Right tast -> ppSourceFile tast
+
+spec :: Spec
+spec = do
+  describe "Pretty printing class methods" $ do
+    it "Prints declaration of class TMChannel without no_handler" $ do
+      renderHeader test0 `shouldBe`
+        pack ("typedef enum {\n" ++
+              "    In,\n" ++
+              "    Out,\n" ++
+              "    Stop,\n" ++
+              "    Reset\n" ++
+              "} __enum_Message;\n" ++
+              "\n" ++
+              "typedef struct {\n" ++
+              "\n" ++   
+              "    __enum_Message __variant;\n" ++
+              "    \n" ++       
+              "    union {\n" ++
+              "        struct {\n" ++
+              "            uint32_t __0;\n" ++
+              "            uint32_t __1;\n" ++
+              "        } __In;\n" ++
+              "        struct {\n" ++
+              "            uint32_t __0;\n" ++
+              "        } __Out;\n" ++
+              "    };\n" ++
+              "\n" ++   
+              "} Message;\n" ++
+              "\n" ++   
+              "typedef struct {\n" ++
+              "    __termina_pool_t * message_pool;\n" ++
+              "    uint32_t interval;\n" ++
+              "    __termina_task_id_t __task_id;\n" ++
+              "} CHousekeeping;\n" ++
+              "\n" ++   
+              "TaskRet __CHousekeeping_run(CHousekeeping * self);\n")
+    it "Prints definition of class TMChannel without no_handler" $ do
+      renderSource test0 `shouldBe`
+        pack ("TaskRet __CHousekeeping_run(CHousekeeping * self) {\n" ++
+              "\n" ++
+              "    TaskRet ret;\n" ++
+              "\n" ++
+              "    {\n" ++
+              "        ret.__variant = Continue;\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    self->interval = self->interval + 1;\n" ++
+              "\n" ++
+              "    __termina_option_dyn_t alloc_msg;\n" ++
+              "\n" ++
+              "    {\n" ++
+              "        alloc_msg.__variant = None;\n" ++
+              "    }\n" ++ 
+              "\n" ++   
+              "    __termina_pool_alloc(self->message_pool, &alloc_msg);\n"  ++
+              "\n"  ++   
+              "    if (alloc_msg.__variant == None) {\n"  ++
+              "\n"  ++   
+              "        \n"  ++           
+              "    } else {\n" ++
+              "\n" ++   
+              "        __termina_pool_free(alloc_msg.__Some.__0);\n" ++
+              "\n" ++  
+              "    }\n" ++
+              "\n" ++   
+              "    return ret;\n" ++
+              "\n" ++   
+              "}\n\n")

--- a/test/UT/PPrinter/Expression/ArithmeticSpec.hs
+++ b/test/UT/PPrinter/Expression/ArithmeticSpec.hs
@@ -11,10 +11,10 @@ import Data.Map
 
 var0 :: Expression SemanticAnns
 -- | var0 : u16
-var0 = AccessObject ( (Variable "var0" uint16SemAnn))
+var0 = AccessObject (Variable "var0" (objSemAnn Mutable UInt16))
 
 undynVar1 :: Expression SemanticAnns
-undynVar1 = AccessObject ( (Undyn (Variable "var1" dynUInt16SemAnn) uint16SemAnn))
+undynVar1 = AccessObject (Undyn (Variable "var1" dynUInt16SemAnn) (objSemAnn Mutable UInt16))
 
 constUInt16 :: Expression SemanticAnns
 -- | 1024 : u16

--- a/test/UT/PPrinter/Expression/BitwiseSpec.hs
+++ b/test/UT/PPrinter/Expression/BitwiseSpec.hs
@@ -11,10 +11,10 @@ import UT.PPrinter.Expression.Common
 
 var0 :: Expression SemanticAnns
 -- | var0 : u16
-var0 = AccessObject (Variable "var0" uint16SemAnn)
+var0 = AccessObject (Variable "var0" (objSemAnn Mutable UInt16))
 
 undynVar1 :: Expression SemanticAnns
-undynVar1 = AccessObject (Undyn (Variable "var1" dynUInt16SemAnn) uint16SemAnn)
+undynVar1 = AccessObject (Undyn (Variable "var1" dynUInt16SemAnn) (objSemAnn Mutable UInt16))
 
 constUInt8, constUInt16 :: Expression SemanticAnns
 constUInt8 = Constant (I UInt8 0x08) uint8SemAnn

--- a/test/UT/PPrinter/Expression/CastSpec.hs
+++ b/test/UT/PPrinter/Expression/CastSpec.hs
@@ -15,7 +15,7 @@ castUInt32toUInt8 = Casting (Constant (I UInt32 0xFFFF0000) uint32SemAnn) UInt8 
 castUInt32toUInt16 = Casting (Constant (I UInt32 0xFFFF0000) uint32SemAnn) UInt16 uint16SemAnn
 
 var0 :: Expression SemanticAnns
-var0 = AccessObject (Variable "var0" uint32SemAnn)
+var0 = AccessObject (Variable "var0" (objSemAnn Mutable UInt32))
 
 castVar0toUInt8, castVar0toUInt32 :: Expression SemanticAnns
 castVar0toUInt8 = Casting var0 UInt8 uint8SemAnn
@@ -25,7 +25,7 @@ tmDescriptor0 :: Object SemanticAnns
 tmDescriptor0 = Variable "tm_descriptor0" (definedTypeSemAnn Mutable "TMDescriptor")
 
 tmDescriptor0field0 :: Object SemanticAnns
-tmDescriptor0field0 = MemberAccess tmDescriptor0 "field0" uint32SemAnn
+tmDescriptor0field0 = MemberAccess tmDescriptor0 "field0" (objSemAnn Mutable UInt32)
 
 castTMDescriptor0field0toUInt8 :: Expression SemanticAnns
 castTMDescriptor0field0toUInt8 = Casting (AccessObject tmDescriptor0field0) UInt8 uint8SemAnn

--- a/test/UT/PPrinter/Expression/Common.hs
+++ b/test/UT/PPrinter/Expression/Common.hs
@@ -111,10 +111,10 @@ refDefinedTypeSemAnn :: Identifier -> SemanticAnns
 refDefinedTypeSemAnn name = refSemAnn (DefinedType name)
 
 poolSemAnn :: TypeSpecifier -> Integer -> SemanticAnns
-poolSemAnn ts size = objSemAnn Immutable (Pool ts (K size))
+poolSemAnn ts size = objSemAnn Mutable (Port (Pool ts (K size)))
 
 msgQueueSemAnn :: TypeSpecifier -> Integer -> SemanticAnns
-msgQueueSemAnn ts size = objSemAnn Immutable (MsgQueue ts (K size))
+msgQueueSemAnn ts size = objSemAnn Mutable (Port (MsgQueue ts (K size)))
 
 funSemAnn :: [Parameter] -> TypeSpecifier -> SemanticAnns
 funSemAnn params ts = SemAnn undefined (ETy (AppType params ts))

--- a/test/UT/PPrinter/Expression/FunctionCallSpec.hs
+++ b/test/UT/PPrinter/Expression/FunctionCallSpec.hs
@@ -28,7 +28,7 @@ referenceVar1 = ReferenceExpression Mutable var1 refUInt16SemAnn
 
 dereferencepVar :: Object SemanticAnns
 -- | *p_var : u16
-dereferencepVar = Dereference pVar uint16SemAnn
+dereferencepVar = Dereference pVar (objSemAnn Mutable UInt16)
 
 vector0, dynVector0 :: Object SemanticAnns
 vector0 = Variable "vector0" (vectorSemAnn Mutable UInt32 (I UInt32 10))
@@ -52,7 +52,7 @@ dereferencepVarPlusConstant = BinOp Addition (AccessObject dereferencepVar) uint
 
 var0PlusVar1, dereferencepVar2PlusVar1 :: Expression SemanticAnns
 var0PlusVar1 = BinOp Addition (AccessObject var0) undynVar1 uint16SemAnn
-dereferencepVar2PlusVar1 = BinOp Addition (AccessObject dereferencepVar) undynVar1 uint16SemAnn
+dereferencepVar2PlusVar1 = BinOp Addition (AccessObject dereferencepVar) undynVar1 (objSemAnn Mutable UInt16)
 
 functionCallSingleVar0, functionCallSingleDynVar1,
   functionCallSinglepVar :: Expression SemanticAnns

--- a/test/UT/PPrinter/Expression/MemberAccessSpec.hs
+++ b/test/UT/PPrinter/Expression/MemberAccessSpec.hs
@@ -20,11 +20,11 @@ undynTMDescriptor1 :: Object SemanticAnns
 undynTMDescriptor1 = Undyn tmDescriptor1 (definedTypeSemAnn Mutable "TMDescriptor")
 
 tmDescriptor0field0, tmDescriptor1field0 :: Expression SemanticAnns
-tmDescriptor0field0 = AccessObject ((MemberAccess tmDescriptor0 "field0" uint32SemAnn))
-tmDescriptor1field0 = AccessObject ((MemberAccess undynTMDescriptor1 "field0" uint32SemAnn))
+tmDescriptor0field0 = AccessObject (MemberAccess tmDescriptor0 "field0" (objSemAnn Mutable UInt32))
+tmDescriptor1field0 = AccessObject (MemberAccess undynTMDescriptor1 "field0" (objSemAnn Mutable UInt32))
 
 pTMDescriptor0field0 :: Expression SemanticAnns
-pTMDescriptor0field0 = AccessObject ((DereferenceMemberAccess pTMDescriptor0 "field0" uint32SemAnn))
+pTMDescriptor0field0 = AccessObject (DereferenceMemberAccess pTMDescriptor0 "field0" (objSemAnn Mutable UInt32))
 
 renderExpression :: Expression SemanticAnns -> Text
 renderExpression = render . ppExpression empty

--- a/test/UT/PPrinter/Expression/MemberFunctionAccessSpec.hs
+++ b/test/UT/PPrinter/Expression/MemberFunctionAccessSpec.hs
@@ -1,4 +1,4 @@
-module UT.PPrinter.Expression.MemberMethodAccessSpec (spec) where
+module UT.PPrinter.Expression.MemberFunctionAccessSpec (spec) where
 
 import Test.Hspec
 import PPrinter
@@ -9,19 +9,19 @@ import PPrinter.Expression
 import UT.PPrinter.Expression.Common
 import Semantic.Monad
 
-resource0, tmChannel, tmPool, bar0, bar1 :: Object SemanticAnns
-resource0 = Variable "resource0" (definedTypeSemAnn Mutable "Resource")
+self, tmChannel, tmPool, bar0, bar1 :: Object SemanticAnns
+self = Variable "self" (refDefinedTypeSemAnn "Resource")
 tmChannel = Variable "tm_channel" (msgQueueSemAnn (DefinedType "TMDescriptor") 10)
 tmPool = Variable "tm_pool" (poolSemAnn UInt32 10)
-bar0 = Variable "bar0" uint16SemAnn
+bar0 = Variable "bar0" (objSemAnn Mutable UInt16)
 bar1 = Variable "bar1" dynUInt16SemAnn
 
 tmPoolAlloc :: Expression SemanticAnns
 tmPoolAlloc = MemberFunctionAccess tmPool "alloc" [] unitSemAnn
 
-tmChannelsend, resource0foo0 :: Expression SemanticAnns
+tmChannelsend, selfFoo0 :: Expression SemanticAnns
 tmChannelsend = MemberFunctionAccess tmChannel "send" [AccessObject bar0] unitSemAnn
-resource0foo0 = MemberFunctionAccess resource0 "foo0" [AccessObject bar0, AccessObject bar1] unitSemAnn
+selfFoo0 = MemberFunctionAccess self "foo0" [AccessObject bar0, AccessObject bar1] unitSemAnn
 
 renderExpression :: Expression SemanticAnns -> Text
 renderExpression = render . ppExpression empty
@@ -31,10 +31,10 @@ spec = do
   describe "Pretty printing method call expressions" $ do
     it "Prints the expression: tm_pool.alloc()" $ do
       renderExpression tmPoolAlloc `shouldBe`
-        pack "__termina_pool_alloc(&tm_pool)"
+        pack "__termina_pool_alloc(tm_pool)"
     it "Prints the expression: tm_channel.foo0(bar0)" $ do
       renderExpression tmChannelsend `shouldBe`
-        pack "__termina_msg_queue_send(&tm_channel, bar0)"
+        pack "__termina_msg_queue_send(tm_channel, bar0)"
     it "Prints the expression: resource.foo0(bar0, bar1)" $ do
-      renderExpression resource0foo0 `shouldBe`
-        pack "__Resource_foo0(&resource0, bar0, bar1)"
+      renderExpression selfFoo0 `shouldBe`
+        pack "__Resource_foo0(self, bar0, bar1)"

--- a/test/UT/PPrinter/Expression/ReferenceSpec.hs
+++ b/test/UT/PPrinter/Expression/ReferenceSpec.hs
@@ -45,7 +45,7 @@ refDynVector0expr = ReferenceExpression Mutable dynVector0 refVectorAnn
 refDynVector1expr = ReferenceExpression Mutable dynVector1 refTwoDymVectorAnn
 
 derefpVar0, derefpVector0, derefpVector1 :: Expression SemanticAnns
-derefpVar0 = AccessObject (Dereference pVar0 uint16SemAnn) -- | *p_var0 |
+derefpVar0 = AccessObject (Dereference pVar0 (objSemAnn Mutable UInt16)) -- | *p_var0 |
 derefpVector0 = AccessObject (Dereference pVector0 vectorAnn) -- | *p_vector0 |
 derefpVector1 = AccessObject (Dereference pVector1 twoDymVectorAnn) -- | *p_vector1 |
 

--- a/test/UT/PPrinter/Expression/RelationalSpec.hs
+++ b/test/UT/PPrinter/Expression/RelationalSpec.hs
@@ -13,11 +13,11 @@ uint16Const1024 :: Expression SemanticAnns
 uint16Const1024 = Constant (I UInt16 1024) uint16SemAnn
 
 var0, var1 :: Object SemanticAnns
-var0 = Variable "var0" uint16SemAnn
+var0 = Variable "var0" (objSemAnn Mutable UInt16)
 var1 = Variable "var1" dynUInt16SemAnn
 
 undynVar1 :: Object SemanticAnns
-undynVar1 = Undyn var1 uint16SemAnn
+undynVar1 = Undyn var1 (objSemAnn Mutable UInt16)
 
 trueBool, falseBool :: Expression SemanticAnns
 trueBool = Constant (B True) boolSemAnn
@@ -25,19 +25,19 @@ falseBool = Constant (B False) boolSemAnn
 
 var0EqConstant, constantEqVar0, var1EqConstant, 
   constantEqVar1, var0EqVar1 :: Expression SemanticAnns
-var0EqConstant = BinOp RelationalEqual (AccessObject (var0)) uint16Const1024 boolSemAnn
-constantEqVar0 = BinOp RelationalEqual uint16Const1024 (AccessObject (var0)) boolSemAnn
-var1EqConstant = BinOp RelationalEqual (AccessObject (undynVar1)) uint16Const1024 boolSemAnn
-constantEqVar1 = BinOp RelationalEqual uint16Const1024 (AccessObject (undynVar1)) boolSemAnn
-var0EqVar1 = BinOp RelationalEqual (AccessObject (var0)) (AccessObject (undynVar1)) boolSemAnn
+var0EqConstant = BinOp RelationalEqual (AccessObject var0) uint16Const1024 boolSemAnn
+constantEqVar0 = BinOp RelationalEqual uint16Const1024 (AccessObject var0) boolSemAnn
+var1EqConstant = BinOp RelationalEqual (AccessObject undynVar1) uint16Const1024 boolSemAnn
+constantEqVar1 = BinOp RelationalEqual uint16Const1024 (AccessObject undynVar1) boolSemAnn
+var0EqVar1 = BinOp RelationalEqual (AccessObject var0) (AccessObject undynVar1) boolSemAnn
 
 var0NeqConstant, constantNeqVar0, var1NeqConstant, 
   constantNeqVar1, var0NeqVar1 :: Expression SemanticAnns
-var0NeqConstant = BinOp RelationalNotEqual (AccessObject (var0)) uint16Const1024 boolSemAnn
-constantNeqVar0 = BinOp RelationalNotEqual uint16Const1024 (AccessObject (var0)) boolSemAnn
-var1NeqConstant = BinOp RelationalNotEqual (AccessObject (undynVar1)) uint16Const1024 boolSemAnn
-constantNeqVar1 = BinOp RelationalNotEqual uint16Const1024 (AccessObject (undynVar1)) boolSemAnn
-var0NeqVar1 = BinOp RelationalNotEqual (AccessObject (var0)) (AccessObject (undynVar1)) boolSemAnn
+var0NeqConstant = BinOp RelationalNotEqual (AccessObject var0) uint16Const1024 boolSemAnn
+constantNeqVar0 = BinOp RelationalNotEqual uint16Const1024 (AccessObject var0) boolSemAnn
+var1NeqConstant = BinOp RelationalNotEqual (AccessObject undynVar1) uint16Const1024 boolSemAnn
+constantNeqVar1 = BinOp RelationalNotEqual uint16Const1024 (AccessObject undynVar1) boolSemAnn
+var0NeqVar1 = BinOp RelationalNotEqual (AccessObject var0) (AccessObject undynVar1) boolSemAnn
 
 var0GTConstant, constantGTVar0, var1GTConstant, 
   constantGTVar1, var0GTVar1 :: Expression SemanticAnns

--- a/test/UT/PPrinter/Expression/VariableSpec.hs
+++ b/test/UT/PPrinter/Expression/VariableSpec.hs
@@ -16,7 +16,7 @@ dynTwoDymVectorAnn = dynTwoDymVectorSemAnn Int64 (I UInt32 5) (I UInt32 10)
 dynThreeDymVectorAnn = dynThreeDymVectorSemAnn Char (I UInt32 40) (I UInt32 5) (I UInt32 10)
 
 var0, vector0, vector1 :: Object SemanticAnns
-var0 = Variable "var0" uint16SemAnn
+var0 = Variable "var0" (objSemAnn Mutable UInt16)
 vector0 = Variable "vector0" vectorAnn
 vector1 = Variable "vector1" twoDymVectorAnn
 
@@ -45,7 +45,7 @@ spec = do
       renderExpression (AccessObject dynVar0) `shouldBe`
         pack "dyn_var0"
     it "Prints the undyned variable dyn_var0 : 'dyn u16" $ do
-      renderExpression (AccessObject (Undyn dynVar0 uint16SemAnn)) `shouldBe`
+      renderExpression (AccessObject (Undyn dynVar0 (objSemAnn Mutable UInt16))) `shouldBe`
         pack "*((uint16_t *)dyn_var0.data)"
     it "Prints the variable dyn_vector1 : 'dyn [[i64; 5 : u32]; 10 : u32]" $ do
       renderExpression (AccessObject dynVector1) `shouldBe`

--- a/test/UT/PPrinter/Expression/VectorIndexSpec.hs
+++ b/test/UT/PPrinter/Expression/VectorIndexSpec.hs
@@ -18,7 +18,7 @@ refVectorAnn :: SemanticAnns
 refVectorAnn = refSemAnn (Vector UInt32 (KC (I UInt32 10)))
 
 var0, vector0, vector1 :: Object SemanticAnns
-var0 = Variable "var0" uint16SemAnn
+var0 = Variable "var0" (objSemAnn Mutable UInt16)
 vector0 = Variable "vector0" vectorAnn
 vector1 = Variable "vector1" twoDymVectorAnn
 
@@ -34,25 +34,25 @@ dynVector0 :: Object SemanticAnns
 dynVector0 = Variable "dyn_vector0" dynVectorAnn
 
 vector0IndexConstant, vector0IndexVar0 :: Expression SemanticAnns
-vector0IndexConstant = AccessObject (VectorIndexExpression vector0 uint8Const0x8 uint32SemAnn)
-vector0IndexVar0 = AccessObject (VectorIndexExpression vector0 (AccessObject var0) uint32SemAnn)
+vector0IndexConstant = AccessObject (VectorIndexExpression vector0 uint8Const0x8 (objSemAnn Mutable UInt32))
+vector0IndexVar0 = AccessObject (VectorIndexExpression vector0 (AccessObject var0) (objSemAnn Mutable UInt32))
 
 dynVector0IndexConstant, dynVector0IndexVar0 :: Expression SemanticAnns
-dynVector0IndexConstant = AccessObject (VectorIndexExpression (Undyn dynVector0 vectorAnn) uint8Const0x8 uint32SemAnn)
-dynVector0IndexVar0 = AccessObject (VectorIndexExpression (Undyn dynVector0 vectorAnn) (AccessObject var0) uint32SemAnn)
+dynVector0IndexConstant = AccessObject (VectorIndexExpression (Undyn dynVector0 vectorAnn) uint8Const0x8 (objSemAnn Mutable UInt32))
+dynVector0IndexVar0 = AccessObject (VectorIndexExpression (Undyn dynVector0 vectorAnn) (AccessObject var0) (objSemAnn Mutable UInt32))
 
 vector1IndexFirstDym :: Object SemanticAnns
 vector1IndexFirstDym = VectorIndexExpression vector1 uint32Index3 (vectorSemAnn Mutable Int64 (I UInt32 5))
 
 vector1IndexExpression :: Expression SemanticAnns
-vector1IndexExpression = AccessObject (VectorIndexExpression vector1IndexFirstDym uint32Index4 int64SemAnn)
+vector1IndexExpression = AccessObject (VectorIndexExpression vector1IndexFirstDym uint32Index4 (objSemAnn Mutable Int64))
 
 derefpVector0 :: Object SemanticAnns
 derefpVector0 = Dereference pVector0 vectorAnn
 
 derefpVector0IndexConstant, derefpVector0IndexVar0 :: Expression SemanticAnns
-derefpVector0IndexConstant = AccessObject (VectorIndexExpression derefpVector0 uint32Index3 uint32SemAnn)
-derefpVector0IndexVar0 = AccessObject (VectorIndexExpression derefpVector0 (AccessObject var0) uint32SemAnn)
+derefpVector0IndexConstant = AccessObject (VectorIndexExpression derefpVector0 uint32Index3 (objSemAnn Mutable UInt32))
+derefpVector0IndexVar0 = AccessObject (VectorIndexExpression derefpVector0 (AccessObject var0) (objSemAnn Mutable UInt32))
 
 renderExpression :: Expression SemanticAnns -> Text
 renderExpression = render . ppExpression empty

--- a/test/UT/PPrinter/FunctionSpec.hs
+++ b/test/UT/PPrinter/FunctionSpec.hs
@@ -166,7 +166,7 @@ spec = do
     it "Prints fuction0 definition" $ do
       renderFunction function0 `shouldBe`
         pack ("void function0() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    TMDescriptor struct0;\n" ++
               "\n" ++
               "    {\n" ++
@@ -188,7 +188,7 @@ spec = do
     it "Prints fuction1 definition" $ do
       renderFunction function1 `shouldBe`
         pack ("uint32_t function1() {\n" ++
-              "    \n" ++
+              "\n" ++
               "    TMDescriptor struct0;\n" ++
               "\n" ++
               "    {\n" ++
@@ -210,7 +210,7 @@ spec = do
     it "Prints fuction2 definition" $ do
       renderFunction function2 `shouldBe`
         pack ("uint32_t function2(uint32_t param0) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    TMDescriptor struct0;\n" ++
               "\n" ++
               "    {\n" ++
@@ -232,7 +232,7 @@ spec = do
     it "Prints fuction3 definition" $ do
       renderFunction function3 `shouldBe`
         pack ("uint32_t function3(uint32_t param0, __param_function3_param1_t param1) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    TMDescriptor struct0;\n" ++
               "\n" ++
               "    {\n" ++
@@ -254,7 +254,7 @@ spec = do
     it "Prints fuction4 definition" $ do
       renderFunction function4 `shouldBe`
         pack ("uint32_t function4(uint32_t param0, uint32_t param1[10]) {\n" ++
-              "    \n" ++
+              "\n" ++
               "    TMDescriptor struct0;\n" ++
               "\n" ++
               "    {\n" ++

--- a/test/UT/PPrinter/Statement/ForLoopSpec.hs
+++ b/test/UT/PPrinter/Statement/ForLoopSpec.hs
@@ -20,7 +20,7 @@ total = AccessObject (Variable "total" (objSemAnn Mutable UInt32))
 i = AccessObject (Variable "i" (objSemAnn Mutable UInt32))
 
 vector0IndexI:: Expression SemanticAnns
-vector0IndexI = AccessObject (VectorIndexExpression vector0 i uint32SemAnn)
+vector0IndexI = AccessObject (VectorIndexExpression vector0 i (objSemAnn Mutable UInt32))
 
 forLoopBody :: [Statement SemanticAnns]
 forLoopBody = [AssignmentStmt (Variable "total" (objSemAnn Mutable UInt32)) (BinOp Addition total vector0IndexI uint32SemAnn) undefined]

--- a/test/UT/PPrinter/Statement/MatchSpec.hs
+++ b/test/UT/PPrinter/Statement/MatchSpec.hs
@@ -30,13 +30,13 @@ optionVar :: Expression SemanticAnns
 optionVar = AccessObject (Variable "option_var" optionDynUInt32SemAnn)
 
 vector0IndexConstant :: Expression SemanticAnns
-vector0IndexConstant = AccessObject (VectorIndexExpression (Undyn param1 vectorAnn) uint8Const0x8 uint32SemAnn)
+vector0IndexConstant = AccessObject (VectorIndexExpression (Undyn param1 vectorAnn) uint8Const0x8 (objSemAnn Mutable UInt32))
 
 foo1 :: Object SemanticAnns
 foo1 = Variable "foo1" (objSemAnn Mutable UInt32)
 
 param0ToFoo1, constToFoo1 :: Statement SemanticAnns
-param0ToFoo1 = AssignmentStmt foo1 (AccessObject (Undyn param0 uint32SemAnn)) undefined
+param0ToFoo1 = AssignmentStmt foo1 (AccessObject (Undyn param0 (objSemAnn Mutable UInt32))) undefined
 constToFoo1 = AssignmentStmt foo1 uint32Const0 undefined
 
 matchCaseSome0 :: MatchCase SemanticAnns

--- a/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
+++ b/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
@@ -31,18 +31,18 @@ twoDymVectorRowAnn = vectorSemAnn Mutable Int64 (I UInt32 5)
 twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (I UInt32 5) (I UInt32 10)
 
 vector0 :: Expression SemanticAnns
-vector0 = AccessObject ( (Variable "vector0" vectorAnn))
+vector0 = AccessObject (Variable "vector0" vectorAnn)
 
 vector1, vector2, vector3, vector4, vector5, vector6 :: Statement SemanticAnns
 vector1 = Declaration "vector1" Mutable vectorTS vector0 undefined
-vector2 = Declaration "vector2" Mutable twoDimVectorTS (AccessObject ( (Variable "vector1" twoDymVectorAnn))) undefined
+vector2 = Declaration "vector2" Mutable twoDimVectorTS (AccessObject (Variable "vector1" twoDymVectorAnn)) undefined
 vector3 = Declaration "vector3" Mutable vectorTS (VectorInitExpression uint32Const0 (KC (I UInt32 10)) vectorAnn) undefined
 vector4 = Declaration "vector4" Mutable twoDimVectorTS (VectorInitExpression (VectorInitExpression uint32Const0 (KC (I UInt32 5)) twoDymVectorRowAnn) (KC (I UInt32 10)) twoDymVectorAnn) undefined
-vector5 = Declaration "vector5" Mutable twoDimVectorTS (VectorInitExpression (AccessObject ( (Variable "vector_row" twoDymVectorRowAnn))) (KC (I UInt32 10)) twoDymVectorAnn) undefined
+vector5 = Declaration "vector5" Mutable twoDimVectorTS (VectorInitExpression (AccessObject (Variable "vector_row" twoDymVectorRowAnn)) (KC (I UInt32 10)) twoDymVectorAnn) undefined
 vector6 = Declaration "vector6" Mutable vectorTMDescriptorTS (VectorInitExpression tmDescriptorFieldsInit0 (KC (I UInt32 10)) vectorTMDescriptorAnn) undefined
 
 foo0 :: Expression SemanticAnns
-foo0 = AccessObject ( (Variable "foo0" uint32SemAnn))
+foo0 = AccessObject (Variable "foo0" (objSemAnn Mutable UInt32))
 
 foo1, foo2 :: Statement SemanticAnns
 foo1 = Declaration "foo1" Mutable UInt32 foo0 undefined
@@ -81,7 +81,7 @@ enum0 = Declaration "enum0" Mutable messageTS (EnumVariantExpression "Message" "
 enum1 = Declaration "enum1" Mutable messageTS (EnumVariantExpression "Message" "In" [uint32Const0, uint32Const0] messageSemAnn) undefined
 
 dynVar0 :: Expression SemanticAnns
-dynVar0 = AccessObject ( (Variable "dyn_var0" dynUInt32SemAnn))
+dynVar0 = AccessObject (Variable "dyn_var0" dynUInt32SemAnn)
 
 option0, option1 :: Statement SemanticAnns
 option0 = Declaration "option0" Mutable optionDynUInt32TS (OptionVariantExpression (Some dynVar0) optionDynUInt32SemAnn) undefined

--- a/test/UT/PPrinter/TypeDef/ClassSpec.hs
+++ b/test/UT/PPrinter/TypeDef/ClassSpec.hs
@@ -19,7 +19,7 @@ classWithOneProcedureAndZeroFields = TypeDefinition (Class ResourceClass "id0" [
       Parameter "param5" Int16,
       Parameter "param6" Int32,
       Parameter "param7" Int64
-    ] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
+    ] [] undefined
   ] []) undefined
 
 classWithTwoProceduresAndZeroFields :: AnnASTElement SemanticAnns
@@ -27,66 +27,74 @@ classWithTwoProceduresAndZeroFields = TypeDefinition (Class ResourceClass "id0" 
     ClassProcedure "procedure0" [
       Parameter "param0" UInt8,
       Parameter "param1" (Option (DynamicSubtype (DefinedType "TMPacket")))
-    ] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined,
+    ] [] undefined,
     ClassProcedure "procedure1" [
       Parameter "param0" UInt8,
       Parameter "param1" (Reference Mutable (Vector UInt8 (KC (I UInt32 32))))
-    ] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
+    ] [] undefined
   ] []) undefined
 
 noHandlerClassWithoutOneProcedureAndZeroFields :: AnnASTElement SemanticAnns
 noHandlerClassWithoutOneProcedureAndZeroFields = TypeDefinition (Class ResourceClass "id0" [
-    ClassProcedure "procedure0" [] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
-  ] [Modifier "no_handler" Nothing]) undefined
+    ClassProcedure "procedure0" [] [] undefined
+  ] []) undefined
 
 classWithOneProcedureAndTwoFields :: AnnASTElement SemanticAnns
 classWithOneProcedureAndTwoFields = TypeDefinition
   (Class ResourceClass "id0" [
-    ClassField "field0" UInt8 undefined,
-    ClassField "field1" (Vector UInt64 (KC (I UInt32 24))) undefined,
-    ClassProcedure "procedure0" [] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
+    ClassField (FieldDefinition "field0" UInt8) undefined,
+    ClassField (FieldDefinition "field1" (Vector UInt64 (KC (I UInt32 24)))) undefined,
+    ClassProcedure "procedure0" [] [] undefined
   ] []) undefined
 
 noHandlerClassWithOneEmptyProcedure :: AnnASTElement SemanticAnns
 noHandlerClassWithOneEmptyProcedure = TypeDefinition
   (Class ResourceClass "id0" [
-    ClassField "field0" UInt8 undefined,
-    ClassField "field1" (Vector UInt64 (KC (I UInt32 24))) undefined,
-    ClassProcedure "procedure0" [] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
+    ClassField (FieldDefinition "field0" UInt8) undefined,
+    ClassField (FieldDefinition "field1" (Vector UInt64 (KC (I UInt32 24)))) undefined,
+    ClassProcedure "procedure0" [] [] undefined
   ] [Modifier "no_handler" Nothing]) undefined
 
 packedClass :: AnnASTElement SemanticAnns
 packedClass = TypeDefinition
   (Class ResourceClass "id0" [
-    ClassField "field0" UInt64 undefined,
-    ClassField "field1" UInt16 undefined,
-    ClassField "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32))) undefined,
+    ClassField (FieldDefinition "field0" UInt64) undefined,
+    ClassField (FieldDefinition "field1" UInt16) undefined,
+    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32)))) undefined,
     ClassProcedure "procedure0" [
       Parameter "param0" Char,
       Parameter "param1" (Reference Mutable (Vector UInt8 (KC (I UInt32 16))))
-    ] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
+    ] [] undefined
   ] [Modifier "packed" Nothing]) undefined
 
 alignedClass :: AnnASTElement SemanticAnns
 alignedClass = TypeDefinition
   (Class ResourceClass "id0" [
-    ClassField "field0" UInt64 undefined,
-    ClassField "field1" UInt16 undefined,
-    ClassField "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32))) undefined,
-    ClassProcedure "procedure0" [] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
+    ClassField (FieldDefinition "field0" UInt64) undefined,
+    ClassField (FieldDefinition "field1" UInt16) undefined,
+    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32)))) undefined,
+    ClassProcedure "procedure0" [] [] undefined
   ] [Modifier "align" (Just (KC (I UInt32 16)))]) undefined
 
 packedAndAlignedClass :: AnnASTElement SemanticAnns
 packedAndAlignedClass = TypeDefinition
   (Class ResourceClass "id0" [
-    ClassField "field0" UInt64 undefined,
-    ClassField "field1" (DefinedType "TCDescriptor") undefined,
-    ClassField "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32))) undefined,
-    ClassProcedure "procedure0" [] Nothing (BlockRet [] (ReturnStmt Nothing undefined)) undefined
+    ClassField (FieldDefinition "field0" UInt64) undefined,
+    ClassField (FieldDefinition "field1" (DefinedType "TCDescriptor")) undefined,
+    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32)))) undefined,
+    ClassProcedure "procedure0" [] [] undefined
   ] [
       Modifier "packed" Nothing,
       Modifier "align" (Just (KC (I UInt32 16)))
     ]) undefined
+
+classWithFixedLocationField :: AnnASTElement SemanticAnns
+classWithFixedLocationField = TypeDefinition
+  (Class ResourceClass "id0" [
+    ClassField (FieldDefinition "field0" UInt32) undefined,
+    ClassField (FieldDefinition "field1" (Location UInt32)) undefined,
+    ClassProcedure "procedure0" [] [] undefined
+  ] []) undefined
 
 renderTypedefDeclaration :: AnnASTElement SemanticAnns -> Text
 renderTypedefDeclaration = render . fromJust . ppHeaderASTElement
@@ -98,49 +106,51 @@ spec = do
       renderTypedefDeclaration classWithOneProcedureAndZeroFields `shouldBe`
         pack (
           "typedef struct {\n" ++
-          "    uint32_t __dummy;\n" ++
+          "    __termina_resource_id_t __resource_id;\n" ++
           "} id0;\n" ++
           "\n" ++
-          "void __id0_procedure0(uint8_t param0, uint16_t param1, uint32_t param2,\n" ++
-          "                      uint64_t param3, int8_t param4, int16_t param5,\n" ++
-          "                      int32_t param6, int64_t param7);\n")
+          "void __id0_procedure0(id0 * self, uint8_t param0, uint16_t param1,\n" ++
+          "                      uint32_t param2, uint64_t param3, int8_t param4,\n" ++
+          "                      int16_t param5, int32_t param6, int64_t param7);\n")
     it "Prints a class with two procedures and zero fields" $ do
       renderTypedefDeclaration classWithTwoProceduresAndZeroFields `shouldBe`
         pack (
           "typedef struct {\n" ++
-          "    uint32_t __dummy;\n" ++
+          "    __termina_resource_id_t __resource_id;\n" ++
           "} id0;\n" ++
           "\n" ++
-          "void __id0_procedure0(uint8_t param0, __termina_option_dyn_t param1);\n" ++
+          "void __id0_procedure0(id0 * self, uint8_t param0,\n" ++
+          "                      __termina_option_dyn_t param1);\n" ++
           "\n" ++
-          "void __id0_procedure1(uint8_t param0, uint8_t param1[32]);\n")
+          "void __id0_procedure1(id0 * self, uint8_t param0, uint8_t param1[32]);\n")
     it "Prints a class marked as no_handler with one procedure and zero fields" $ do
       renderTypedefDeclaration noHandlerClassWithoutOneProcedureAndZeroFields `shouldBe`
         pack (
             "typedef struct {\n" ++
-            "    __termina_mutex_id_t __mutex_id;\n" ++
+            "    __termina_resource_id_t __resource_id;\n" ++
             "} id0;\n" ++
             "\n" ++
-            "void __id0_procedure0();\n")
+            "void __id0_procedure0(id0 * self);\n")
     it "Prints a class marked as no_handler with two fields" $ do
       renderTypedefDeclaration noHandlerClassWithOneEmptyProcedure `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
             "    uint64_t field1[24];\n" ++
-            "    __termina_mutex_id_t __mutex_id;\n" ++
+            "    __termina_resource_id_t __resource_id;\n" ++
             "} id0;\n" ++
             "\n" ++
-            "void __id0_procedure0();\n")
+            "void __id0_procedure0(id0 * self);\n")
     it "Prints a class with one procedure and two fields" $ do
       renderTypedefDeclaration classWithOneProcedureAndTwoFields `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
             "    uint64_t field1[24];\n" ++
+            "    __termina_resource_id_t __resource_id;\n" ++
             "} id0;\n" ++
             "\n" ++
-            "void __id0_procedure0();\n")
+            "void __id0_procedure0(id0 * self);\n")
     it "Prints a packed class" $ do
       renderTypedefDeclaration packedClass `shouldBe`
         pack (
@@ -148,9 +158,10 @@ spec = do
             "    uint64_t field0;\n" ++
             "    uint16_t field1;\n" ++
             "    TMDescriptor field2[32];\n" ++
+            "    __termina_resource_id_t __resource_id;\n" ++
             "} __attribute__((packed)) id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(char param0, uint8_t param1[16]);\n")
+            "void __id0_procedure0(id0 * self, char param0, uint8_t param1[16]);\n")
     it "Prints an aligned class" $ do
       renderTypedefDeclaration alignedClass `shouldBe`
         pack (
@@ -158,9 +169,10 @@ spec = do
             "    uint64_t field0;\n" ++
             "    uint16_t field1;\n" ++
             "    TMDescriptor field2[32];\n" ++
+            "    __termina_resource_id_t __resource_id;\n" ++
             "} __attribute__((align(16))) id0;\n" ++
             "\n" ++
-            "void __id0_procedure0();\n")
+            "void __id0_procedure0(id0 * self);\n")
     it "Prints a packed & aligned class" $ do
       renderTypedefDeclaration packedAndAlignedClass `shouldBe`
         pack (
@@ -168,6 +180,17 @@ spec = do
             "    uint64_t field0;\n" ++
             "    TCDescriptor field1;\n" ++
             "    TMDescriptor field2[32];\n" ++
+            "    __termina_resource_id_t __resource_id;\n" ++
             "} __attribute__((packed, align(16))) id0;\n" ++
             "\n" ++
-            "void __id0_procedure0();\n")
+            "void __id0_procedure0(id0 * self);\n")
+    it "Prints a class with a fixed location field" $ do
+      renderTypedefDeclaration classWithFixedLocationField `shouldBe`
+        pack (
+            "typedef struct {\n" ++
+            "    uint32_t field0;\n" ++
+            "    volatile uint32_t * field1;\n" ++
+            "    __termina_resource_id_t __resource_id;\n" ++
+            "} id0;\n" ++
+            "\n" ++
+            "void __id0_procedure0(id0 * self);\n")


### PR DESCRIPTION
This commit contains the following changes:

- Modification of the AST to include the "port" subtype. This subtype can be used in the definition of the fields of a class to represent the connection of a global object (task, handler or resource) to an external resource. Now, global objects are not directly accessible from the class code, but must be accessed through a port. These ports, being private objects, can only be used from the code of the class itself. It is not possible to create references to them from anywhere. The connection between ports and external resources is made only once, at the time of instantiation of the corresponding task, handler or resource.
- Since global objects can no longer be accessed from any code block, the functions getLHSVarTy and getRHSVarTy have been modified to access only the local environment. Any attempt to access a global variable causes an error.
- Fixed the definition of procedures. Due to an error, the definition of procedures allowed them to return a value. The procedures are used to implement the external interface of the resources and do not return any value.
- Fixed several bugs in the parser that did not allow the parsing of access expressions to port procedures. Since access now always has to be done through a port, port access expressions are of type ```self->port.procedure()```. A new right-hand side object parser had to be added to allow parsing of such expressions.
- The ClassField definition has been modified to incorporate a FieldDefinition instead of a separate identifier and type. In this way, the functions used to check the fields of the structures can be partially reused.
- Following @elsamoreno's suggestion, the concrete syntax of the functions has been modified back to use `->` instead of `:` to specify the type of the return value.
- New tests have been defined to test the code generation of the tasks.
- Several unit tests containing incorrect manual annotations have been corrected.
- The printer has been modified to avoid indenting the blank line right at the beginning of the functions.

The `typeDefCheck` function **DOES NOT WORK CORRECTLY** for classes. The function generates a dependency graph from the code of the different functions of the classes to detect recursive calls, but the resulting sorted list contains errors. All the offending lines (790 to 824) have been commented out. The function code needs to be revised. If we are not going to allow the user to reference functions or fields in an order other than that defined by the class, it may not be necessary to perform these operations.

It is necessary to define a document to keep track of the to-do list.