### PR TITLE
Change in the definition of arrays

### DIFF
--- a/src/AST/Core.hs
+++ b/src/AST/Core.hs
@@ -98,9 +98,9 @@ type Address = Integer
 data TypeSpecifier
   -- Primitive types
   = UInt8 | UInt16 | UInt32 | UInt64
-  | Int8 | Int16 | Int32 | Int64
+  | Int8 | Int16 | Int32 | Int64 | USize
   | Bool | Char | DefinedType Identifier
-  | Vector TypeSpecifier ConstExpression
+  | Vector TypeSpecifier Size
   | Option TypeSpecifier
   -- Non-primitive types
   | MsgQueue TypeSpecifier Size
@@ -297,7 +297,7 @@ data Expression'
   --
   -- These four constructors cannot be used on regular (primitive?) expressions
   -- These two can only be used as the RHS of an assignment:
-  | VectorInitExpression (Expression' obj a) ConstExpression a -- ^ Vector initializer, | (13 : i8) + (2 : i8)|
+  | VectorInitExpression (Expression' obj a) Size a -- ^ Vector initializer, | (13 : i8) + (2 : i8)|
   | FieldAssignmentsExpression
     Identifier -- ^ Structure type identifier
     [FieldAssignment' (Expression' obj) a] -- ^ Initial value of each field identifier

--- a/src/PPrinter/Common.hs
+++ b/src/PPrinter/Common.hs
@@ -124,6 +124,9 @@ charC = pretty "char"
 boolC :: DocStyle
 boolC = pretty "_Bool"
 
+sizeTC :: DocStyle
+sizeTC = pretty "size_t"
+
 -- C pretty extern
 externC :: DocStyle
 externC = pretty "extern"
@@ -180,6 +183,7 @@ ppTypeSpecifier Int8                         = int8C
 ppTypeSpecifier Int16                        = int16C
 ppTypeSpecifier Int32                        = int32C
 ppTypeSpecifier Int64                        = int64C
+ppTypeSpecifier USize                        = sizeTC
 ppTypeSpecifier Bool                         = boolC
 ppTypeSpecifier Char                         = charC
 ppTypeSpecifier (DefinedType typeIdentifier) = pretty typeIdentifier
@@ -198,7 +202,7 @@ ppTypeSpecifier (Port ts)                    = ppTypeSpecifier ts <+> pretty "*"
 ppTypeSpecifier t                            = error $ "unsupported type: " ++ show t
 
 ppDimension :: TypeSpecifier -> DocStyle
-ppDimension (Vector ts (KC size)) = brackets (ppConst size) <> ppDimension ts
+ppDimension (Vector ts (K size)) = brackets (pretty size) <> ppDimension ts
 ppDimension _                     = emptyDoc
 
 ppReturnVectorValueStructure :: DocStyle -> DocStyle

--- a/src/PPrinter/Expression.hs
+++ b/src/PPrinter/Expression.hs
@@ -43,10 +43,10 @@ ppDynamicSubtypeCast (Vector ts _) =
 ppDynamicSubtypeCast ts = ppTypeSpecifier ts <+> pretty "*"
 
 ppDynamicSubtypeCast' :: TypeSpecifier -> DocStyle
-ppDynamicSubtypeCast' (Vector ts (KC vs)) =
+ppDynamicSubtypeCast' (Vector ts (K vs)) =
     case ts of
-        (Vector _ _) -> brackets (ppConst vs) <> ppDynamicSubtypeCast' ts
-        _ -> brackets (ppConst vs)
+        (Vector _ _) -> brackets (pretty vs) <> ppDynamicSubtypeCast' ts
+        _ -> brackets (pretty vs)
 ppDynamicSubtypeCast' ts = error $ "unsupported type" ++ show ts
 
 -- | Pretty prints the address of the object corresponding to the dynamic subtype

--- a/src/PPrinter/Statement/VariableInitialization.hs
+++ b/src/PPrinter/Statement/VariableInitialization.hs
@@ -16,10 +16,10 @@ ppInitializeVectorFromExpression level target source ts =
   let iterator = namefy ("i" ++ show level)
    in case ts of
         -- \| If the initializer is a vector, we must iterate
-        (Vector ts' (KC (I indexTS size))) ->
+        (Vector ts' (K size)) ->
           let initExpr =
                 ppCForLoopInitExpression
-                  (ppTypeSpecifier indexTS)
+                  (ppTypeSpecifier USize)
                   (pretty iterator)
                   (pretty (show (0 :: Integer)))
               condExpr =
@@ -47,10 +47,10 @@ ppInitializeVector subs level target expr =
    in case expr of
         (FieldAssignmentsExpression {}) -> ppInitializeStruct subs level target expr
         (OptionVariantExpression {}) -> ppInitializeOption subs level target expr
-        (VectorInitExpression expr' (KC (I indexTS size)) _) ->
+        (VectorInitExpression expr' (K size) _) ->
           let initExpr =
                 ppCForLoopInitExpression
-                  (ppTypeSpecifier indexTS)
+                  (ppTypeSpecifier USize)
                   (pretty iterator)
                   (pretty (show (0 :: Integer)))
            in let condExpr =

--- a/src/Semantic/Errors.hs
+++ b/src/Semantic/Errors.hs
@@ -22,6 +22,7 @@ data Errors a
   | ECasteable TypeSpecifier TypeSpecifier
   -- | Expected Numeric Types
   | ENumTs [TypeSpecifier]
+  | EUSizeTs TypeSpecifier
   -- | Reference of a global type?
   | EReferenceGlobal Identifier
   -- | Not Variable found
@@ -192,7 +193,7 @@ data Errors a
   | ELowerBoundConst ConstExpression -- | Lower bound is not a numeric constant expression
   | EUpperBoundConst ConstExpression -- | Upper bound is not a numeric constant expression
   | EBoundsTypeMismatch TypeSpecifier TypeSpecifier -- | Lower and upper bounds are not of the same type
-  | EBoundsAndVectorTypeMismatch TypeSpecifier TypeSpecifier -- | Bounds are not of the same type as the vector
+  | EBoundsTypeNotUSize TypeSpecifier TypeSpecifier -- | Bounds are not of of type usize
   | EBoundsLowerGTUpper Integer Integer -- | Lower bound is greater than upper bound
   | EUpperBoundGTSize Integer Integer -- | Upper bound is greater than the size of the vector
   deriving Show

--- a/src/Utils/AST/Parser.hs
+++ b/src/Utils/AST/Parser.hs
@@ -4,8 +4,6 @@ module Utils.AST.Parser where
 
 import           AST.Parser
 
-import Control.Arrow
-
 -- Ground Type equality
 groundTyEq :: TypeSpecifier -> TypeSpecifier -> Bool
 groundTyEq  UInt8  UInt8 = True
@@ -16,6 +14,7 @@ groundTyEq  Int8  Int8 = True
 groundTyEq  Int16  Int16 = True
 groundTyEq  Int32  Int32 = True
 groundTyEq  Int64  Int64 = True
+groundTyEq  USize  USize = True
 groundTyEq  Bool  Bool = True
 groundTyEq  Unit Unit = True
 groundTyEq  (Option _) (Option Unit) = True
@@ -25,7 +24,7 @@ groundTyEq  (Reference Mutable tyspecl) (Reference Mutable tyspecr) = groundTyEq
 groundTyEq  (Reference Immutable tyspecl) (Reference Immutable tyspecr) = groundTyEq tyspecl tyspecr
 groundTyEq  (DynamicSubtype tyspecl) (DynamicSubtype tyspecr) = groundTyEq tyspecl tyspecr
 -- TODO: These are considered complex types and should be handled differently
-groundTyEq  (Vector typespecl sizeel) (Vector typespecr sizer) = groundTyEq typespecl typespecr && constExprEq sizeel sizer
+groundTyEq  (Vector typespecl (K sizel)) (Vector typespecr (K sizer)) = groundTyEq typespecl typespecr && sizel == sizer
 groundTyEq  (DefinedType idl) (DefinedType idr) = idl == idr
 -- Location subtypes
 groundTyEq  (Location tyspecl) (Location tyspecr) = groundTyEq tyspecl tyspecr

--- a/src/Utils/TypeSpecifier.hs
+++ b/src/Utils/TypeSpecifier.hs
@@ -14,6 +14,7 @@ primitiveTypes Int8            = True
 primitiveTypes Int16           = True
 primitiveTypes Int32           = True
 primitiveTypes Int64           = True
+primitiveTypes USize           = True
 primitiveTypes Bool            = True
 primitiveTypes Char            = True
 primitiveTypes (DefinedType _) = True
@@ -56,6 +57,7 @@ numTy Int8   = True
 numTy Int16  = True
 numTy Int32  = True
 numTy Int64  = True
+numTy USize  = True
 numTy _      = False
 
 numCons :: Const -> Bool
@@ -75,6 +77,10 @@ memberIntCons i Int8   = ( -128 <= i ) && ( i <= 127 )
 memberIntCons i Int16  = ( -32768 <= i ) && ( i <= 32767 )
 memberIntCons i Int32  = ( -2147483648 <= i ) && ( i <= 2147483647 )
 memberIntCons i Int64  = ( -9223372036854775808 <= i ) && ( i <= 9223372036854775807 )
+-- | TODO: This value depends on the target architecture and shall be selected
+-- accordingly. Since we are currently targeting 32-bit systems, we assume that
+-- usize is a 32-bit unsigned integer.
+memberIntCons i USize  = ( 0 <= i ) && ( i <= 4294967295)
 memberIntCons _ _      = False
 
 identifierType :: TypeDef' expr lho a -> Identifier

--- a/test/IT/Expression/FunctionCallSpec.hs
+++ b/test/IT/Expression/FunctionCallSpec.hs
@@ -18,16 +18,16 @@ test0 = "function func_test0_0(a : u16) -> u16 {\n" ++
         "}"
 
 test1 :: String
-test1 = "function func_test1_0() -> [u32; 10 : u32] {\n" ++
-        "    var foo : [u32; 10 : u32] = [1024 : u32; 10 : u32];\n" ++
+test1 = "function func_test1_0() -> [u32; 10] {\n" ++
+        "    var foo : [u32; 10] = [1024 : u32; 10];\n" ++
         "    return foo;\n" ++
         "}\n" ++
         "\n" ++
         "function func_test1_1() -> u32 {\n" ++
-        "    var bar0 : [u32; 10 : u32] = [0 : u32; 10 : u32];\n" ++
+        "    var bar0 : [u32; 10] = [0 : u32; 10];\n" ++
         "    bar0 = func_test1_0();\n" ++
-        "    var bar1 : [u32; 10 : u32] = func_test1_0();\n" ++
-        "    return bar0[1 : u32] + bar1[2 : u32];\n" ++
+        "    var bar1 : [u32; 10] = func_test1_0();\n" ++
+        "    return bar0[1 : usize] + bar1[2 : usize];\n" ++
         "}"
 
 renderHeader :: String -> Text
@@ -84,7 +84,7 @@ spec = do
               "    uint32_t foo[10];\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            foo[__i0] = 1024;\n" ++
               "        }\n" ++
               "    }\n" ++
@@ -98,7 +98,7 @@ spec = do
               "    uint32_t bar0[10];\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            bar0[__i0] = 0;\n" ++
               "        }\n" ++
               "    }\n" ++

--- a/test/IT/Expression/VectorIndexSpec.hs
+++ b/test/IT/Expression/VectorIndexSpec.hs
@@ -9,20 +9,20 @@ import Text.Parsec
 
 test0 :: String
 test0 = "function vector_test0() {\n" ++
-        "    var foo : u32 = 0 : u32;\n" ++
-        "    var vector0 : [u32; 10 : u32] = [0 : u32; 10 : u32];\n" ++
-        "    var vector1 : [[i64; 5 : u32]; 10 : u16] = [[0 : i64; 5 : u32]; 10 : u16];\n" ++
-        "    vector0[3 : u32] = 10 : u32;\n" ++
+        "    var foo : usize = 0 : usize;\n" ++
+        "    var vector0 : [u32; 10] = [0 : u32; 10];\n" ++
+        "    var vector1 : [[i64; 5]; 10] = [[0 : i64; 5]; 10];\n" ++
+        "    vector0[3 : usize] = 10 : u32;\n" ++
         "    vector0[foo] = 1024 : u32;\n" ++
-        "    vector1[3 : u16][4 : u32] = 1024 : i64;\n" ++
+        "    vector1[3 : usize][4 : usize] = 1024 : i64;\n" ++
         "    return;\n" ++
         "}"
 
 test1 :: String
-test1 = "function vector_test1(p_vector0 : & [u32; 10 : u32]) {\n" ++
+test1 = "function vector_test1(p_vector0 : & [u32; 10]) {\n" ++
         "    var foo : u32 = 0 : u32;\n" ++
-        "    (*p_vector0)[3 : u32] = 10 : u32;\n" ++
-        "    (*p_vector0)[foo] = 1024 : u32;\n" ++
+        "    (*p_vector0)[3 : usize] = 10 : u32;\n" ++
+        "    (*p_vector0)[foo as usize] = 1024 : u32;\n" ++
         "    return;\n" ++
         "}"
 
@@ -52,12 +52,12 @@ spec = do
       renderSource test0 `shouldBe`
         pack ("void vector_test0() {\n" ++
               "\n" ++
-              "    uint32_t foo = 0;\n" ++
+              "    size_t foo = 0;\n" ++
               "\n" ++
               "    uint32_t vector0[10];\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            vector0[__i0] = 0;\n" ++
               "        }\n" ++
               "    }\n" ++
@@ -65,8 +65,8 @@ spec = do
               "    int64_t vector1[10][5];\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint16_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
-              "            for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "            for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
               "                vector1[__i0][__i1] = 0;\n" ++
               "            }\n" ++
               "        }\n" ++
@@ -92,7 +92,7 @@ spec = do
               "\n" ++
               "    p_vector0[3] = 10;\n" ++
               "\n" ++
-              "    p_vector0[foo] = 1024;\n" ++
+              "    p_vector0[(size_t)foo] = 1024;\n" ++
               "\n" ++
               "    return;\n" ++
               "\n" ++

--- a/test/IT/Expression/VectorSliceSpec.hs
+++ b/test/IT/Expression/VectorSliceSpec.hs
@@ -9,40 +9,40 @@ import Text.Parsec
 
 test0 :: String
 test0 = "function slice_test0() {\n" ++
-        "    var vector0 : [u32; 10 : u32] = [0 : u32; 10 : u32];\n" ++
-        "    vector0[3 : u32..10 : u32][1 : u32] = 10 : u32;\n" ++
+        "    var vector0 : [u32; 10] = [0 : u32; 10];\n" ++
+        "    vector0[3 : usize .. 10 : usize][1 : usize] = 10 : u32;\n" ++
         "    return;\n" ++
         "}"
 
 test1 :: String
-test1 = "function slice_test1(vector0 : & [[[u32; 3 : u32]; 5 : u32]; 10 : u32]) {\n" ++
-        "    (*vector0)[3 : u32 .. 8 : u32] = [[[10 : u32; 3 : u32]; 5 : u32]; 5 : u32];\n" ++
+test1 = "function slice_test1(vector0 : & [[[u32; 3]; 5]; 10]) {\n" ++
+        "    (*vector0)[3 : usize .. 8 : usize] = [[[10 : u32; 3]; 5]; 5];\n" ++
         "    return;\n" ++
         "}"
 
 test2 :: String
-test2 = "function add_one(input : & [u32; 5 : u32]) {\n" ++ 
-        "    for i : u32 in 0 : u32 .. 5 : u32 {\n" ++
+test2 = "function add_one(input : & [u32; 5]) {\n" ++ 
+        "    for i : usize in 0 : usize .. 5 : usize {\n" ++
         "        (*input)[i] = (*input)[i] + 1 : u32;\n" ++
         "    }\n" ++
         "    return;\n" ++
         "}\n" ++
         "\n" ++
-        "function slice_test2(vector0 : & [[u32; 5 : u32]; 10 : u32]) {\n" ++
-        "    add_one(&(*vector0)[2 : u32 .. 3 : u32][0 : u32]);\n" ++
+        "function slice_test2(vector0 : & [[u32; 5]; 10]) {\n" ++
+        "    add_one(&(*vector0)[2 : usize .. 3 : usize][0 : usize]);\n" ++
         "    return;\n" ++
         "}"
 
 test3 :: String
-test3 = "function add_two(input : [u32; 5 : u32]) {\n" ++ 
-        "    for i : u32 in 0 : u32 .. 5 : u32 {\n" ++
+test3 = "function add_two(input : [u32; 5]) {\n" ++ 
+        "    for i : usize in 0 : usize .. 5 : usize {\n" ++
         "        input[i] = input[i] + 2 : u32;\n" ++
         "    }\n" ++
         "    return;\n" ++
         "}\n" ++
         "\n" ++
-        "function slice_test3(vector0 : & [[u32; 5 : u32]; 10 : u32]) {\n" ++
-        "    add_two((*vector0)[2 : u32 .. 3 : u32][0 : u32]);\n" ++
+        "function slice_test3(vector0 : & [[u32; 5]; 10]) {\n" ++
+        "    add_two((*vector0)[2 : usize .. 3 : usize][0 : usize]);\n" ++
         "    return;\n" ++
         "}"
 
@@ -75,7 +75,7 @@ spec = do
               "    uint32_t vector0[10];\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            vector0[__i0] = 0;\n" ++
               "        }\n" ++
               "    }\n" ++
@@ -93,9 +93,9 @@ spec = do
         pack ("void slice_test1(uint32_t vector0[10][5][3]) {\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 5; __i0 = __i0 + 1) {\n" ++
-              "            for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
-              "                for (uint32_t __i2 = 0; __i2 < 3; __i2 = __i2 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 5; __i0 = __i0 + 1) {\n" ++
+              "            for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+              "                for (size_t __i2 = 0; __i2 < 3; __i2 = __i2 + 1) {\n" ++
               "                    (&vector0[3])[__i0][__i1][__i2] = 10;\n" ++
               "                }\n" ++
               "            }\n" ++
@@ -115,10 +115,10 @@ spec = do
         pack ("void add_one(uint32_t input[5]) {\n" ++
               "\n" ++
               "    {\n" ++
-              "        uint32_t __start = 0;\n" ++
-              "        uint32_t __end = 5;\n" ++
+              "        size_t __start = 0;\n" ++
+              "        size_t __end = 5;\n" ++
               "\n" ++
-              "        for (uint32_t i = __start; i < __end; i = i + 1) {\n" ++
+              "        for (size_t i = __start; i < __end; i = i + 1) {\n" ++
               "            \n" ++
               "            input[i] = input[i] + 1;\n" ++
               "\n" ++
@@ -150,10 +150,10 @@ spec = do
         pack ("void add_two(__param_add_two_input_t input) {\n" ++
               "\n" ++
               "    {\n" ++
-              "        uint32_t __start = 0;\n" ++
-              "        uint32_t __end = 5;\n" ++
+              "        size_t __start = 0;\n" ++
+              "        size_t __end = 5;\n" ++
               "\n" ++
-              "        for (uint32_t i = __start; i < __end; i = i + 1) {\n" ++
+              "        for (size_t i = __start; i < __end; i = i + 1) {\n" ++
               "            \n" ++
               "            input.array[i] = input.array[i] + 2;\n" ++
               "\n" ++

--- a/test/IT/Statement/AssignmentSpec.hs
+++ b/test/IT/Statement/AssignmentSpec.hs
@@ -32,8 +32,8 @@ test2 = "function assignment_test2(dyn_var0 : dyn u32, dyn_var1 : dyn u32) {\n" 
         "}"
 
 test3 :: String
-test3 = "function assignment_test3(dyn_var0 : dyn [u32; 10 : u32], dyn_var1 : dyn [u32; 10 : u32]) {\n" ++
-        "    var foo : [u32; 10 : u32] = [0 : u32; 10 : u32];\n" ++
+test3 = "function assignment_test3(dyn_var0 : dyn [u32; 10], dyn_var1 : dyn [u32; 10]) {\n" ++
+        "    var foo : [u32; 10] = [0 : u32; 10];\n" ++
         "    dyn_var0 = foo;\n" ++
         "    foo = dyn_var1;\n" ++
         "    dyn_var1 = dyn_var0;\n" ++
@@ -124,25 +124,25 @@ spec = do
               "    uint32_t foo[10];\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            foo[__i0] = 0;\n" ++
               "        }\n" ++
               "    }\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            ((uint32_t *)dyn_var0.data)[__i0] = foo[__i0];\n" ++
               "        }\n" ++
               "    }\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            foo[__i0] = ((uint32_t *)dyn_var1.data)[__i0];\n" ++
               "        }\n" ++
               "    }\n" ++
               "\n" ++
               "    {\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            ((uint32_t *)dyn_var1.data)[__i0] = ((uint32_t *)dyn_var0.data)[__i0];\n" ++
               "        }\n" ++
               "    }\n" ++

--- a/test/IT/Statement/ForLoopSpec.hs
+++ b/test/IT/Statement/ForLoopSpec.hs
@@ -8,18 +8,18 @@ import Semantic.TypeChecking
 import Text.Parsec
 
 test0 :: String
-test0 = "function for_loop_test0(array0 : [u16; 10 : u32]) -> u16 {\n" ++
+test0 = "function for_loop_test0(array0 : [u16; 10]) -> u16 {\n" ++
         "    var total : u16 = 0 : u16;\n" ++
-        "    for i : u32 in 0 : u32 .. 10 : u32 {\n" ++
+        "    for i : usize in 0 : usize .. 10 : usize {\n" ++
         "        total = total + array0[i];\n" ++  
         "    }\n" ++
         "    return total;\n" ++
         "}"
 
 test1 :: String
-test1 = "function for_loop_test1(array0 : & [u16; 10 : u32]) -> bool {\n" ++
+test1 = "function for_loop_test1(array0 : & [u16; 10]) -> bool {\n" ++
         "    var found : bool = false;\n" ++
-        "    for i : u32 in 0 : u32 .. 10 : u32 while found == false {\n" ++
+        "    for i : usize in 0 : usize .. 10 : usize while found == false {\n" ++
         "        if (*array0)[i] == 1024 : u16 {\n" ++
         "            found = true;\n" ++
         "        }\n" ++   
@@ -60,10 +60,10 @@ spec = do
               "    uint16_t total = 0;\n" ++
               "\n" ++
               "    {\n" ++
-              "        uint32_t __start = 0;\n" ++
-              "        uint32_t __end = 10;\n" ++
+              "        size_t __start = 0;\n" ++
+              "        size_t __end = 10;\n" ++
               "\n" ++
-              "        for (uint32_t i = __start; i < __end; i = i + 1) {\n" ++
+              "        for (size_t i = __start; i < __end; i = i + 1) {\n" ++
               "            \n" ++
               "            total = total + array0.array[i];\n" ++
               "\n" ++
@@ -83,10 +83,10 @@ spec = do
               "    _Bool found = 0;\n" ++
               "\n" ++
               "    {\n" ++
-              "        uint32_t __start = 0;\n" ++
-              "        uint32_t __end = 10;\n" ++
+              "        size_t __start = 0;\n" ++
+              "        size_t __end = 10;\n" ++
               "\n" ++
-              "        for (uint32_t i = __start; i < __end && (found == 0); i = i + 1) {\n" ++
+              "        for (size_t i = __start; i < __end && (found == 0); i = i + 1) {\n" ++
               "            \n" ++
               "            if (array0[i] == 1024) {\n" ++
               "\n" ++

--- a/test/UT/PPrinter/Expression/Common.hs
+++ b/test/UT/PPrinter/Expression/Common.hs
@@ -14,7 +14,7 @@ unitSemAnn :: SemanticAnns
 unitSemAnn = simpleTySemAnn Unit
 
 uint8SemAnn, uint32SemAnn, uint16SemAnn, uint64SemAnn, int8SemAnn,
-    int16SemAnn, int32SemAnn, int64SemAnn, charSemAnn, boolSemAnn :: SemanticAnns
+    int16SemAnn, int32SemAnn, int64SemAnn, usizeSemAnn, charSemAnn, boolSemAnn :: SemanticAnns
 uint8SemAnn = simpleTySemAnn UInt8
 uint32SemAnn = simpleTySemAnn UInt32
 uint16SemAnn = simpleTySemAnn UInt16
@@ -23,6 +23,7 @@ int8SemAnn = simpleTySemAnn Int8
 int16SemAnn = simpleTySemAnn Int16
 int32SemAnn = simpleTySemAnn Int32
 int64SemAnn = simpleTySemAnn Int64
+usizeSemAnn = simpleTySemAnn USize
 charSemAnn = simpleTySemAnn Char
 boolSemAnn = simpleTySemAnn Bool
 
@@ -61,43 +62,43 @@ refInt64SemAnn = refSemAnn Int64
 refCharSemAnn = refSemAnn Char
 refBoolSemAnn = refSemAnn Bool
 
-vectorSemAnn :: AccessKind -> TypeSpecifier -> Const -> SemanticAnns
-vectorSemAnn ak ts size = objSemAnn ak (Vector ts (KC size))
+vectorSemAnn :: AccessKind -> TypeSpecifier -> Size -> SemanticAnns
+vectorSemAnn ak ts size = objSemAnn ak (Vector ts size)
 
-dynVectorSemAnn :: TypeSpecifier -> Const -> SemanticAnns
-dynVectorSemAnn ts size = objSemAnn Mutable (DynamicSubtype (Vector ts (KC size)))
+dynVectorSemAnn :: TypeSpecifier -> Size -> SemanticAnns
+dynVectorSemAnn ts size = objSemAnn Mutable (DynamicSubtype (Vector ts size))
 
-refVectorSemAnn :: TypeSpecifier -> Const -> SemanticAnns
-refVectorSemAnn ts size = objSemAnn Immutable (Reference Mutable (Vector ts (KC size)))
+refVectorSemAnn :: TypeSpecifier -> Size -> SemanticAnns
+refVectorSemAnn ts size = objSemAnn Immutable (Reference Mutable (Vector ts size))
 
-refTwoDymVectorSemAnn :: TypeSpecifier -> Const -> Const -> SemanticAnns
-refTwoDymVectorSemAnn ts size1 size2 = objSemAnn Immutable (Reference Mutable (Vector (Vector ts (KC size1)) (KC size2)))
+refTwoDymVectorSemAnn :: TypeSpecifier -> Size -> Size -> SemanticAnns
+refTwoDymVectorSemAnn ts size1 size2 = objSemAnn Immutable (Reference Mutable (Vector (Vector ts size1) size2))
 
-uint16VecSemAnn, uint32VecSemAnn :: AccessKind -> Const -> SemanticAnns
+uint16VecSemAnn, uint32VecSemAnn :: AccessKind -> Size -> SemanticAnns
 uint16VecSemAnn ak = vectorSemAnn ak UInt16
 uint32VecSemAnn ak = vectorSemAnn ak UInt32
 
-twoDymVectorSemAnn :: AccessKind -> TypeSpecifier -> Const -> Const -> SemanticAnns
-twoDymVectorSemAnn ak ts size1 size2 = objSemAnn ak (Vector (Vector ts (KC size1)) (KC size2))
+twoDymVectorSemAnn :: AccessKind -> TypeSpecifier -> Size -> Size -> SemanticAnns
+twoDymVectorSemAnn ak ts size1 size2 = objSemAnn ak (Vector (Vector ts size1) size2)
 
-uint16TwoDymVecSemAnn, uint32TwoDymVecSemAnn :: AccessKind -> Const -> Const -> SemanticAnns
+uint16TwoDymVecSemAnn, uint32TwoDymVecSemAnn :: AccessKind -> Size -> Size -> SemanticAnns
 uint16TwoDymVecSemAnn ak = twoDymVectorSemAnn ak UInt16
 uint32TwoDymVecSemAnn ak = twoDymVectorSemAnn ak UInt32
 
-dynTwoDymVectorSemAnn :: TypeSpecifier -> Const -> Const -> SemanticAnns
-dynTwoDymVectorSemAnn ts size1 size2 = objSemAnn Mutable (DynamicSubtype (Vector (Vector ts (KC size1)) (KC size2)))
+dynTwoDymVectorSemAnn :: TypeSpecifier -> Size -> Size -> SemanticAnns
+dynTwoDymVectorSemAnn ts size1 size2 = objSemAnn Mutable (DynamicSubtype (Vector (Vector ts size1) size2))
 
-dynThreeDymVectorSemAnn :: TypeSpecifier -> Const -> Const -> Const -> SemanticAnns
-dynThreeDymVectorSemAnn ts size1 size2 size3 = objSemAnn Mutable (DynamicSubtype (Vector (Vector (Vector ts (KC size1)) (KC size2)) (KC size3)))
+dynThreeDymVectorSemAnn :: TypeSpecifier -> Size -> Size -> Size -> SemanticAnns
+dynThreeDymVectorSemAnn ts size1 size2 size3 = objSemAnn Mutable (DynamicSubtype (Vector (Vector (Vector ts size1) size2) size3))
 
-uint16DynTwoDymVecSemAnn, uint32DynTwoDymVecSemAnn :: Const -> Const -> SemanticAnns
+uint16DynTwoDymVecSemAnn, uint32DynTwoDymVecSemAnn :: Size -> Size -> SemanticAnns
 uint16DynTwoDymVecSemAnn = dynTwoDymVectorSemAnn UInt16
 uint32DynTwoDymVecSemAnn = dynTwoDymVectorSemAnn UInt32
 
-threeDymVectorSemAnn :: AccessKind -> TypeSpecifier -> Const -> Const -> Const -> SemanticAnns
-threeDymVectorSemAnn ak ts size1 size2 size3 = objSemAnn ak (Vector (Vector (Vector ts (KC size1)) (KC size2)) (KC size3))
+threeDymVectorSemAnn :: AccessKind -> TypeSpecifier -> Size -> Size -> Size -> SemanticAnns
+threeDymVectorSemAnn ak ts size1 size2 size3 = objSemAnn ak (Vector (Vector (Vector ts size1) size2) size3)
 
-uint16ThreeDymVecSemAnn, uint32ThreeDymVecSemAnn :: AccessKind -> Const -> Const -> Const -> SemanticAnns
+uint16ThreeDymVecSemAnn, uint32ThreeDymVecSemAnn :: AccessKind -> Size -> Size -> Size -> SemanticAnns
 uint16ThreeDymVecSemAnn ak = threeDymVectorSemAnn ak UInt16
 uint32ThreeDymVecSemAnn ak = threeDymVectorSemAnn ak UInt32
 

--- a/test/UT/PPrinter/Expression/FunctionCallSpec.hs
+++ b/test/UT/PPrinter/Expression/FunctionCallSpec.hs
@@ -31,14 +31,14 @@ dereferencepVar :: Object SemanticAnns
 dereferencepVar = Dereference pVar (objSemAnn Mutable UInt16)
 
 vector0, dynVector0 :: Object SemanticAnns
-vector0 = Variable "vector0" (vectorSemAnn Mutable UInt32 (I UInt32 10))
-dynVector0 = Variable "dynVector0" (dynVectorSemAnn UInt32 (I UInt32 10))
+vector0 = Variable "vector0" (vectorSemAnn Mutable UInt32 (K 10))
+dynVector0 = Variable "dynVector0" (dynVectorSemAnn UInt32 (K 10))
 
 pVector1 :: Expression SemanticAnns
-pVector1 = AccessObject (Variable "p_vector1" (refVectorSemAnn UInt32 (I UInt32 10)))
+pVector1 = AccessObject (Variable "p_vector1" (refVectorSemAnn UInt32 (K 10)))
 
 referenceVector0 :: Expression SemanticAnns
-referenceVector0 = ReferenceExpression Mutable vector0 (refVectorSemAnn UInt32 (I UInt32 10))
+referenceVector0 = ReferenceExpression Mutable vector0 (refVectorSemAnn UInt32 (K 10))
 
 uint16Const :: Expression SemanticAnns
 uint16Const = Constant (I UInt16 1024) uint16SemAnn
@@ -67,7 +67,7 @@ functionCallSingleRefDynVar1 = FunctionExpression "foo" [referenceVar1] (funSemA
 functionCallSingleDerefpVar = FunctionExpression "foo" [AccessObject dereferencepVar] (funSemAnn [Parameter "param0" UInt16] Unit)
 
 functionCallRetArray :: Expression SemanticAnns
-functionCallRetArray = FunctionExpression "foo" [] (funSemAnn [] (Vector UInt32 (KC (I UInt32 10))))
+functionCallRetArray = FunctionExpression "foo" [] (funSemAnn [] (Vector UInt32 (K 10)))
 
 functionCallSingleVar0PlusConstant, functionCallSingleDynVar1PlusConstant,
   functionCallSingleVar0PlusVar1,
@@ -81,12 +81,12 @@ functionCallSingleDerefpVarPlusDerefRefVar1 = FunctionExpression "foo" [derefere
 
 functionCallSingleVector0, functionCallSingleDynVector0,
   functionCallSinglepVector1 :: Expression SemanticAnns
-functionCallSingleVector0 = FunctionExpression "foo" [AccessObject vector0] (funSemAnn [Parameter "param0" (Vector UInt32 (KC (I UInt32 10)))] Unit)
-functionCallSingleDynVector0 = FunctionExpression "foo" [AccessObject dynVector0] (funSemAnn [Parameter "param0" (DynamicSubtype (Vector UInt32 (KC (I UInt32 10))))] Unit)
-functionCallSinglepVector1 = FunctionExpression "foo" [pVector1] (funSemAnn [Parameter "param0" (Reference Mutable (Vector UInt32 (KC (I UInt32 10))))] Unit)
+functionCallSingleVector0 = FunctionExpression "foo" [AccessObject vector0] (funSemAnn [Parameter "param0" (Vector UInt32 (K 10))] Unit)
+functionCallSingleDynVector0 = FunctionExpression "foo" [AccessObject dynVector0] (funSemAnn [Parameter "param0" (DynamicSubtype (Vector UInt32 (K 10)))] Unit)
+functionCallSinglepVector1 = FunctionExpression "foo" [pVector1] (funSemAnn [Parameter "param0" (Reference Mutable (Vector UInt32 (K 10)))] Unit)
 
 functionCallSingleRefVector0 :: Expression SemanticAnns
-functionCallSingleRefVector0 = FunctionExpression "foo" [referenceVector0] (funSemAnn [Parameter "param0" (Reference Mutable (Vector UInt32 (KC (I UInt32 10))))] Unit)
+functionCallSingleRefVector0 = FunctionExpression "foo" [referenceVector0] (funSemAnn [Parameter "param0" (Reference Mutable (Vector UInt32 (K 10)))] Unit)
 
 call2Parameters, call3Parameters, call4Parameters :: Expression SemanticAnns
 call2Parameters = FunctionExpression "foo2" [var0PlusConstant, var0PlusVar1] (funSemAnn [Parameter "param0" UInt16, Parameter "param1" UInt16] UInt16)
@@ -97,7 +97,7 @@ call3Parameters = FunctionExpression "foo3"
     var1PlusConstant
   ] (funSemAnn [
     Parameter "param0" (Reference Mutable UInt16),
-    Parameter "param1" (Vector UInt32 (KC (I UInt32 10))),
+    Parameter "param1" (Vector UInt32 (K 10)),
     Parameter "param2" UInt16
     ] Unit)
 call4Parameters = FunctionExpression "foo4"
@@ -107,7 +107,7 @@ call4Parameters = FunctionExpression "foo4"
     functionCallSingleVar0,
     call2Parameters
   ] (funSemAnn [
-    Parameter "param0" (DynamicSubtype (Vector UInt32 (KC (I UInt32 10)))),
+    Parameter "param0" (DynamicSubtype (Vector UInt32 (K 10))),
     Parameter "param1" (Reference Mutable UInt16),
     Parameter "param2" UInt16,
     Parameter "param3" UInt16

--- a/test/UT/PPrinter/Expression/ReferenceSpec.hs
+++ b/test/UT/PPrinter/Expression/ReferenceSpec.hs
@@ -10,14 +10,14 @@ import UT.PPrinter.Expression.Common
 import Semantic.Monad
 
 vectorAnn, dynVectorAnn, twoDymVectorAnn, dynTwoDymVectorAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
-dynVectorAnn = dynVectorSemAnn UInt32 (I UInt32 10)
-twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (I UInt32 5) (I UInt32 10)
-dynTwoDymVectorAnn = dynTwoDymVectorSemAnn Int64 (I UInt32 5) (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
+dynVectorAnn = dynVectorSemAnn UInt32 (K 10)
+twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (K 5) (K 10)
+dynTwoDymVectorAnn = dynTwoDymVectorSemAnn Int64 (K 5) (K 10)
 
 refVectorAnn, refTwoDymVectorAnn :: SemanticAnns
-refVectorAnn = refVectorSemAnn UInt32 (I UInt32 10)
-refTwoDymVectorAnn = refTwoDymVectorSemAnn Int64 (I UInt32 5) (I UInt32 10)
+refVectorAnn = refVectorSemAnn UInt32 (K 10)
+refTwoDymVectorAnn = refTwoDymVectorSemAnn Int64 (K 5) (K 10)
 
 var0, vector0, vector1 :: Object SemanticAnns
 var0 = Variable "var0" (objSemAnn Mutable UInt16)

--- a/test/UT/PPrinter/Expression/VariableSpec.hs
+++ b/test/UT/PPrinter/Expression/VariableSpec.hs
@@ -10,10 +10,10 @@ import PPrinter.Expression
 import UT.PPrinter.Expression.Common
 
 vectorAnn, twoDymVectorAnn, dynTwoDymVectorAnn, dynThreeDymVectorAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
-twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (I UInt32 5) (I UInt32 10)
-dynTwoDymVectorAnn = dynTwoDymVectorSemAnn Int64 (I UInt32 5) (I UInt32 10)
-dynThreeDymVectorAnn = dynThreeDymVectorSemAnn Char (I UInt32 40) (I UInt32 5) (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
+twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (K 5) (K 10)
+dynTwoDymVectorAnn = dynTwoDymVectorSemAnn Int64 (K 5) (K 10)
+dynThreeDymVectorAnn = dynThreeDymVectorSemAnn Char (K 40) (K 5) (K 10)
 
 var0, vector0, vector1 :: Object SemanticAnns
 var0 = Variable "var0" (objSemAnn Mutable UInt16)

--- a/test/UT/PPrinter/Expression/VectorIndexSpec.hs
+++ b/test/UT/PPrinter/Expression/VectorIndexSpec.hs
@@ -10,12 +10,12 @@ import PPrinter.Expression
 import UT.PPrinter.Expression.Common
 
 vectorAnn, dynVectorAnn, twoDymVectorAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
-dynVectorAnn = dynVectorSemAnn UInt32 (I UInt32 10)
-twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (I UInt32 5) (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
+dynVectorAnn = dynVectorSemAnn UInt32 (K 10)
+twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (K 5) (K 10)
 
 refVectorAnn :: SemanticAnns
-refVectorAnn = refSemAnn (Vector UInt32 (KC (I UInt32 10)))
+refVectorAnn = refSemAnn (Vector UInt32 (K 10))
 
 var0, vector0, vector1 :: Object SemanticAnns
 var0 = Variable "var0" (objSemAnn Mutable UInt16)
@@ -25,33 +25,33 @@ vector1 = Variable "vector1" twoDymVectorAnn
 pVector0 :: Object SemanticAnns
 pVector0 = Variable "p_vector0" refVectorAnn
 
-uint32Index3, uint32Index4, uint8Const0x8 :: Expression SemanticAnns
-uint32Index3 = Constant (I UInt32 3) uint32SemAnn
-uint32Index4 = Constant (I UInt32 4) uint32SemAnn
-uint8Const0x8 = Constant (I UInt8 8) uint8SemAnn
+usizeIndex3, usizeIndex4, usizeConst0x8 :: Expression SemanticAnns
+usizeIndex3 = Constant (I USize 3) usizeSemAnn
+usizeIndex4 = Constant (I USize 4) usizeSemAnn
+usizeConst0x8 = Constant (I USize 8) usizeSemAnn
 
 dynVector0 :: Object SemanticAnns
 dynVector0 = Variable "dyn_vector0" dynVectorAnn
 
 vector0IndexConstant, vector0IndexVar0 :: Expression SemanticAnns
-vector0IndexConstant = AccessObject (VectorIndexExpression vector0 uint8Const0x8 (objSemAnn Mutable UInt32))
+vector0IndexConstant = AccessObject (VectorIndexExpression vector0 usizeConst0x8 (objSemAnn Mutable UInt32))
 vector0IndexVar0 = AccessObject (VectorIndexExpression vector0 (AccessObject var0) (objSemAnn Mutable UInt32))
 
 dynVector0IndexConstant, dynVector0IndexVar0 :: Expression SemanticAnns
-dynVector0IndexConstant = AccessObject (VectorIndexExpression (Undyn dynVector0 vectorAnn) uint8Const0x8 (objSemAnn Mutable UInt32))
+dynVector0IndexConstant = AccessObject (VectorIndexExpression (Undyn dynVector0 vectorAnn) usizeConst0x8 (objSemAnn Mutable UInt32))
 dynVector0IndexVar0 = AccessObject (VectorIndexExpression (Undyn dynVector0 vectorAnn) (AccessObject var0) (objSemAnn Mutable UInt32))
 
 vector1IndexFirstDym :: Object SemanticAnns
-vector1IndexFirstDym = VectorIndexExpression vector1 uint32Index3 (vectorSemAnn Mutable Int64 (I UInt32 5))
+vector1IndexFirstDym = VectorIndexExpression vector1 usizeIndex3 (vectorSemAnn Mutable Int64 (K 5))
 
 vector1IndexExpression :: Expression SemanticAnns
-vector1IndexExpression = AccessObject (VectorIndexExpression vector1IndexFirstDym uint32Index4 (objSemAnn Mutable Int64))
+vector1IndexExpression = AccessObject (VectorIndexExpression vector1IndexFirstDym usizeIndex4 (objSemAnn Mutable Int64))
 
 derefpVector0 :: Object SemanticAnns
 derefpVector0 = Dereference pVector0 vectorAnn
 
 derefpVector0IndexConstant, derefpVector0IndexVar0 :: Expression SemanticAnns
-derefpVector0IndexConstant = AccessObject (VectorIndexExpression derefpVector0 uint32Index3 (objSemAnn Mutable UInt32))
+derefpVector0IndexConstant = AccessObject (VectorIndexExpression derefpVector0 usizeIndex3 (objSemAnn Mutable UInt32))
 derefpVector0IndexVar0 = AccessObject (VectorIndexExpression derefpVector0 (AccessObject var0) (objSemAnn Mutable UInt32))
 
 renderExpression :: Expression SemanticAnns -> Text

--- a/test/UT/PPrinter/FunctionSpec.hs
+++ b/test/UT/PPrinter/FunctionSpec.hs
@@ -16,10 +16,10 @@ constUInt32 :: Expression SemanticAnns
 constUInt32 = Constant (I UInt32 1024) uint32SemAnn
 
 vectorAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
 
 refVectorAnn :: SemanticAnns
-refVectorAnn = refVectorSemAnn UInt32 (I UInt32 10)
+refVectorAnn = refVectorSemAnn UInt32 (K 10)
 
 structASemAnn, tmDescriptorSemAnn :: SemanticAnns
 structASemAnn = definedTypeSemAnn Mutable "StructA"
@@ -35,14 +35,14 @@ structAFieldsInit0 :: Expression SemanticAnns
 structAFieldsInit0 = 
     FieldAssignmentsExpression "StructA"
         [FieldValueAssignment "field_a" uint32Const0,
-         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (KC (I UInt32 10)) vectorAnn),
+         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (K 10) vectorAnn),
          FieldValueAssignment "field_c" uint32Const0xFFFF0000] structASemAnn
 
 structAFieldsInit1 :: Expression SemanticAnns
 structAFieldsInit1 = 
     FieldAssignmentsExpression "StructA"
         [FieldValueAssignment "field_a" (AccessObject (Variable "param0" (objSemAnn Mutable UInt32))),
-         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (KC (I UInt32 10)) vectorAnn),
+         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (K 10) vectorAnn),
          FieldValueAssignment "field_c" uint32Const0xFFFF0000] structASemAnn
 
 structAFieldsInit2 :: Expression SemanticAnns
@@ -119,7 +119,7 @@ function2 = Function "function2" [Parameter "param0" UInt32] (Just UInt32)
     struct0Assignment0] returnStructField0) [] unitSemAnn
 
 function3 :: AnnASTElement SemanticAnns
-function3 = Function "function3" [Parameter "param0" UInt32, Parameter "param1" (Vector UInt32 (KC (I UInt32 10)))] (Just UInt32) 
+function3 = Function "function3" [Parameter "param0" UInt32, Parameter "param1" (Vector UInt32 (K 10))] (Just UInt32) 
   (BlockRet [
     struct0Declaration2, 
     struct1Declaration, 
@@ -127,7 +127,7 @@ function3 = Function "function3" [Parameter "param0" UInt32, Parameter "param1" 
     ] returnStructField0) [] unitSemAnn
 
 function4 :: AnnASTElement SemanticAnns
-function4 = Function "function4" [Parameter "param0" UInt32, Parameter "param1" (Reference Mutable (Vector UInt32 (KC (I UInt32 10))))] (Just UInt32) 
+function4 = Function "function4" [Parameter "param0" UInt32, Parameter "param1" (Reference Mutable (Vector UInt32 (K 10)))] (Just UInt32) 
   (BlockRet [
     struct0Declaration3, 
     struct1Declaration, 
@@ -172,7 +172,7 @@ spec = do
               "    {\n" ++
               "        struct0.field0 = 0;\n" ++
               "        struct0.field1.field_a = 0;\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            struct0.field1.field_b[__i0] = 0;\n" ++
               "        }\n" ++
               "        struct0.field1.field_c = 4294901760;\n" ++
@@ -194,7 +194,7 @@ spec = do
               "    {\n" ++
               "        struct0.field0 = 0;\n" ++
               "        struct0.field1.field_a = 0;\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            struct0.field1.field_b[__i0] = 0;\n" ++
               "        }\n" ++
               "        struct0.field1.field_c = 4294901760;\n" ++
@@ -216,7 +216,7 @@ spec = do
               "    {\n" ++
               "        struct0.field0 = 0;\n" ++
               "        struct0.field1.field_a = param0;\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            struct0.field1.field_b[__i0] = 0;\n" ++
               "        }\n" ++
               "        struct0.field1.field_c = 4294901760;\n" ++
@@ -238,7 +238,7 @@ spec = do
               "    {\n" ++
               "        struct0.field0 = 0;\n" ++
               "        struct0.field1.field_a = param0;\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            struct0.field1.field_b[__i0] = param1.array[__i0];\n" ++
               "        }\n" ++
               "        struct0.field1.field_c = 4294901760;\n" ++
@@ -260,7 +260,7 @@ spec = do
               "    {\n" ++
               "        struct0.field0 = 0;\n" ++
               "        struct0.field1.field_a = param0;\n" ++
-              "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+              "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
               "            struct0.field1.field_b[__i0] = param1[__i0];\n" ++
               "        }\n" ++
               "        struct0.field1.field_c = 4294901760;\n" ++

--- a/test/UT/PPrinter/Statement/AssignmentSpec.hs
+++ b/test/UT/PPrinter/Statement/AssignmentSpec.hs
@@ -16,10 +16,10 @@ optionDynUInt32SemAnn :: SemanticAnns
 optionDynUInt32SemAnn = optionDynSemAnn Mutable UInt32
 
 vectorAnn, vectorTMDescriptorAnn, twoDymVectorAnn, twoDymVectorRowAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
-vectorTMDescriptorAnn = vectorSemAnn Mutable tmDescriptorTS (I UInt32 20)
-twoDymVectorRowAnn = vectorSemAnn Mutable Int64 (I UInt32 5)
-twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (I UInt32 5) (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
+vectorTMDescriptorAnn = vectorSemAnn Mutable tmDescriptorTS (K 20)
+twoDymVectorRowAnn = vectorSemAnn Mutable Int64 (K 5)
+twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (K 5) (K 10)
 
 vector1, vector2, vector3, vector4, vector5, vector6 :: Object SemanticAnns
 vector1 = Variable "vector1" vectorAnn
@@ -32,10 +32,10 @@ vector6 = Variable "vector6" vectorTMDescriptorAnn
 vector1Assign, vector2Assign, vector3Assign, vector4Assign, vector5Assign, vector6Assign :: Statement SemanticAnns
 vector1Assign = AssignmentStmt vector1 (AccessObject (Variable "vector0" vectorAnn)) undefined
 vector2Assign = AssignmentStmt vector2 (AccessObject (Variable "vector1" twoDymVectorAnn)) undefined
-vector3Assign = AssignmentStmt vector3 (VectorInitExpression uint32Const0 (KC (I UInt32 10)) vectorAnn) undefined
-vector4Assign = AssignmentStmt vector4 (VectorInitExpression (VectorInitExpression uint32Const0 (KC (I UInt32 5)) twoDymVectorRowAnn) (KC (I UInt32 10)) twoDymVectorAnn) undefined
-vector5Assign = AssignmentStmt vector5 (VectorInitExpression (AccessObject (Variable "vector_row" twoDymVectorRowAnn)) (KC (I UInt32 10)) twoDymVectorAnn) undefined
-vector6Assign = AssignmentStmt vector6 (VectorInitExpression tmDescriptorFieldsInit0 (KC (I UInt32 10)) vectorTMDescriptorAnn) undefined
+vector3Assign = AssignmentStmt vector3 (VectorInitExpression uint32Const0 (K 10) vectorAnn) undefined
+vector4Assign = AssignmentStmt vector4 (VectorInitExpression (VectorInitExpression uint32Const0 (K 5) twoDymVectorRowAnn) (K 10) twoDymVectorAnn) undefined
+vector5Assign = AssignmentStmt vector5 (VectorInitExpression (AccessObject (Variable "vector_row" twoDymVectorRowAnn)) (K 10) twoDymVectorAnn) undefined
+vector6Assign = AssignmentStmt vector6 (VectorInitExpression tmDescriptorFieldsInit0 (K 10) vectorTMDescriptorAnn) undefined
 
 foo1, foo2 :: Object SemanticAnns
 foo1 = Variable "foo1" (objSemAnn Mutable UInt32)
@@ -60,7 +60,7 @@ structAFieldsInit0 :: Expression SemanticAnns
 structAFieldsInit0 = 
     FieldAssignmentsExpression "StructA"
         [FieldValueAssignment "field_a" uint32Const0,
-         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (KC (I UInt32 10)) vectorAnn),
+         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (K 10) vectorAnn),
          FieldValueAssignment "field_c" uint32Const0xFFFF0000] structASemAnn
 
 tmDescriptorFieldsInit0 :: Expression SemanticAnns
@@ -152,7 +152,7 @@ spec = do
         "{\n" ++
         "    struct0.field0 = 0;\n" ++
         "    struct0.field1.field_a = 0;\n" ++
-        "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+        "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
         "        struct0.field1.field_b[__i0] = 0;\n" ++
         "    }\n" ++
         "    struct0.field1.field_c = 4294901760;\n" ++
@@ -165,7 +165,7 @@ spec = do
       renderStatement vector1Assign `shouldBe`
         pack (
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "        vector1[__i0] = vector0[__i0];\n" ++
           "    }\n" ++
           "}")
@@ -173,8 +173,8 @@ spec = do
       renderStatement vector2Assign `shouldBe`
         pack (
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
           "            vector2[__i0][__i1] = vector1[__i0][__i1];\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -183,7 +183,7 @@ spec = do
       renderStatement vector3Assign `shouldBe`
         pack (
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "        vector3[__i0] = 0;\n" ++
           "    }\n" ++
           "}")
@@ -191,8 +191,8 @@ spec = do
       renderStatement vector4Assign `shouldBe`
         pack (
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
           "            vector4[__i0][__i1] = 0;\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -201,8 +201,8 @@ spec = do
       renderStatement vector5Assign `shouldBe`
         pack (
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
           "            vector5[__i0][__i1] = vector_row[__i1];\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -212,10 +212,10 @@ spec = do
       renderStatement vector6Assign `shouldBe`
         pack (
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "        vector6[__i0].field0 = 0;\n" ++
           "        vector6[__i0].field1.field_a = 0;\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 10; __i1 = __i1 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 10; __i1 = __i1 + 1) {\n" ++
           "            vector6[__i0].field1.field_b[__i1] = 0;\n" ++
           "        }\n" ++
           "        vector6[__i0].field1.field_c = 4294901760;\n" ++

--- a/test/UT/PPrinter/Statement/ForLoopSpec.hs
+++ b/test/UT/PPrinter/Statement/ForLoopSpec.hs
@@ -10,14 +10,14 @@ import PPrinter.Statement
 import UT.PPrinter.Expression.Common
 
 vectorAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
 
 vector0 :: Object SemanticAnns
 vector0 = Variable "vector0" vectorAnn
 
 total, i :: Expression SemanticAnns
 total = AccessObject (Variable "total" (objSemAnn Mutable UInt32))
-i = AccessObject (Variable "i" (objSemAnn Mutable UInt32))
+i = AccessObject (Variable "i" (objSemAnn Mutable USize))
 
 vector0IndexI:: Expression SemanticAnns
 vector0IndexI = AccessObject (VectorIndexExpression vector0 i (objSemAnn Mutable UInt32))
@@ -26,13 +26,13 @@ forLoopBody :: [Statement SemanticAnns]
 forLoopBody = [AssignmentStmt (Variable "total" (objSemAnn Mutable UInt32)) (BinOp Addition total vector0IndexI uint32SemAnn) undefined]
 
 breakCond :: Expression SemanticAnns
-breakCond = BinOp RelationalNotEqual i (Constant (I UInt32 5) uint32SemAnn) boolSemAnn
+breakCond = BinOp RelationalNotEqual i (Constant (I USize 5) uint32SemAnn) boolSemAnn
 
 forLoop0 :: Statement SemanticAnns
-forLoop0 = ForLoopStmt "i" UInt32 (Constant (I UInt32 0) uint32SemAnn) (Constant (I UInt32 10) uint32SemAnn) Nothing forLoopBody undefined
+forLoop0 = ForLoopStmt "i" USize (Constant (I USize 0) uint32SemAnn) (Constant (I USize 10) uint32SemAnn) Nothing forLoopBody undefined
 
 forLoop1 :: Statement SemanticAnns
-forLoop1 = ForLoopStmt "i" UInt32 (Constant (I UInt32 0) uint32SemAnn) (Constant (I UInt32 10) uint32SemAnn) (Just breakCond) forLoopBody undefined
+forLoop1 = ForLoopStmt "i" USize (Constant (I USize 0) uint32SemAnn) (Constant (I USize 10) uint32SemAnn) (Just breakCond) forLoopBody undefined
 
 renderStatement :: Statement SemanticAnns -> Text
 renderStatement = render . ppStatement empty
@@ -44,10 +44,10 @@ spec = do
       renderStatement forLoop0 `shouldBe`
         pack (
           "{\n" ++
-          "    uint32_t __start = 0;\n" ++
-          "    uint32_t __end = 10;\n" ++
+          "    size_t __start = 0;\n" ++
+          "    size_t __end = 10;\n" ++
           "\n" ++
-          "    for (uint32_t i = __start; i < __end; i = i + 1) {\n" ++
+          "    for (size_t i = __start; i < __end; i = i + 1) {\n" ++
           "        \n" ++
           "        total = total + vector0[i];\n" ++
           "\n" ++
@@ -57,10 +57,10 @@ spec = do
       renderStatement forLoop1 `shouldBe`
         pack (
           "{\n" ++
-          "    uint32_t __start = 0;\n" ++
-          "    uint32_t __end = 10;\n" ++
+          "    size_t __start = 0;\n" ++
+          "    size_t __end = 10;\n" ++
           "\n" ++
-          "    for (uint32_t i = __start; i < __end && (i != 5); i = i + 1) {\n" ++
+          "    for (size_t i = __start; i < __end && (i != 5); i = i + 1) {\n" ++
           "        \n" ++
           "        total = total + vector0[i];\n" ++
           "\n" ++

--- a/test/UT/PPrinter/Statement/FreeSpec.hs
+++ b/test/UT/PPrinter/Statement/FreeSpec.hs
@@ -10,7 +10,7 @@ import PPrinter.Statement
 import UT.PPrinter.Expression.Common
 
 dynVectorAnn :: SemanticAnns
-dynVectorAnn = dynVectorSemAnn UInt32 (I UInt32 10)
+dynVectorAnn = dynVectorSemAnn UInt32 (K 10)
 
 dynVar0, dynVector0 :: Object SemanticAnns
 dynVar0 = Variable "dyn_var0" dynUInt32SemAnn

--- a/test/UT/PPrinter/Statement/IfElseSpec.hs
+++ b/test/UT/PPrinter/Statement/IfElseSpec.hs
@@ -13,13 +13,13 @@ optionDynUInt32TS :: TypeSpecifier
 optionDynUInt32TS = Option (DynamicSubtype UInt32)
 
 vectorTS :: TypeSpecifier
-vectorTS = Vector UInt32 (KC (I UInt32 10))
+vectorTS = Vector UInt32 (K 10)
 
 optionDynUInt32SemAnn :: SemanticAnns
 optionDynUInt32SemAnn = optionDynSemAnn Mutable UInt32
 
 vectorAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
 
 vector0 :: Expression SemanticAnns
 vector0 = AccessObject (Variable "vector0" vectorAnn)
@@ -83,7 +83,7 @@ spec = do
           "    uint32_t vector1[10];\n" ++
           "\n" ++
           "    {\n" ++
-          "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "            vector1[__i0] = vector0[__i0];\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -104,7 +104,7 @@ spec = do
           "    uint32_t vector1[10];\n" ++
           "\n" ++
           "    {\n" ++
-          "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "            vector1[__i0] = vector0[__i0];\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -133,7 +133,7 @@ spec = do
           "    uint32_t vector1[10];\n" ++
           "\n" ++
           "    {\n" ++
-          "        for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "            vector1[__i0] = vector0[__i0];\n" ++
           "        }\n" ++
           "    }\n" ++

--- a/test/UT/PPrinter/Statement/MatchSpec.hs
+++ b/test/UT/PPrinter/Statement/MatchSpec.hs
@@ -13,8 +13,8 @@ optionDynUInt32SemAnn :: SemanticAnns
 optionDynUInt32SemAnn = optionDynSemAnn Mutable UInt32
 
 vectorAnn, dynVectorAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
-dynVectorAnn = dynVectorSemAnn UInt32 (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
+dynVectorAnn = dynVectorSemAnn UInt32 (K 10)
 
 param0, param1 :: Object SemanticAnns
 param0 = Variable "param0" dynUInt32SemAnn
@@ -23,14 +23,14 @@ param1 = Variable "param1" dynVectorAnn
 uint32Const0 :: Expression SemanticAnns
 uint32Const0 = Constant (I UInt32 0) uint32SemAnn
 
-uint8Const0x8 :: Expression SemanticAnns
-uint8Const0x8 = Constant (I UInt8 8) uint8SemAnn
+usizeConst0x8 :: Expression SemanticAnns
+usizeConst0x8 = Constant (I USize 8) usizeSemAnn
 
 optionVar :: Expression SemanticAnns
 optionVar = AccessObject (Variable "option_var" optionDynUInt32SemAnn)
 
 vector0IndexConstant :: Expression SemanticAnns
-vector0IndexConstant = AccessObject (VectorIndexExpression (Undyn param1 vectorAnn) uint8Const0x8 (objSemAnn Mutable UInt32))
+vector0IndexConstant = AccessObject (VectorIndexExpression (Undyn param1 vectorAnn) usizeConst0x8 (objSemAnn Mutable UInt32))
 
 foo1 :: Object SemanticAnns
 foo1 = Variable "foo1" (objSemAnn Mutable UInt32)

--- a/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
+++ b/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
@@ -17,18 +17,18 @@ optionDynUInt32TS :: TypeSpecifier
 optionDynUInt32TS = Option (DynamicSubtype UInt32)
 
 vectorTS, vectorTMDescriptorTS, twoDimVectorTS :: TypeSpecifier
-vectorTS = Vector UInt32 (KC (I UInt32 10))
-vectorTMDescriptorTS = Vector tmDescriptorTS (KC (I UInt32 20))
-twoDimVectorTS = Vector (Vector Int64 (KC (I UInt32 5))) (KC (I UInt32 10))
+vectorTS = Vector UInt32 (K 10)
+vectorTMDescriptorTS = Vector tmDescriptorTS (K 20)
+twoDimVectorTS = Vector (Vector Int64 (K 5)) (K 10)
 
 optionDynUInt32SemAnn :: SemanticAnns
 optionDynUInt32SemAnn = optionDynSemAnn Mutable UInt32
 
 vectorAnn, vectorTMDescriptorAnn, twoDymVectorAnn, twoDymVectorRowAnn :: SemanticAnns
-vectorAnn = vectorSemAnn Mutable UInt32 (I UInt32 10)
-vectorTMDescriptorAnn = vectorSemAnn Mutable tmDescriptorTS (I UInt32 20)
-twoDymVectorRowAnn = vectorSemAnn Mutable Int64 (I UInt32 5)
-twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (I UInt32 5) (I UInt32 10)
+vectorAnn = vectorSemAnn Mutable UInt32 (K 10)
+vectorTMDescriptorAnn = vectorSemAnn Mutable tmDescriptorTS (K 20)
+twoDymVectorRowAnn = vectorSemAnn Mutable Int64 (K 5)
+twoDymVectorAnn = twoDymVectorSemAnn Mutable Int64 (K 5) (K 10)
 
 vector0 :: Expression SemanticAnns
 vector0 = AccessObject (Variable "vector0" vectorAnn)
@@ -36,10 +36,10 @@ vector0 = AccessObject (Variable "vector0" vectorAnn)
 vector1, vector2, vector3, vector4, vector5, vector6 :: Statement SemanticAnns
 vector1 = Declaration "vector1" Mutable vectorTS vector0 undefined
 vector2 = Declaration "vector2" Mutable twoDimVectorTS (AccessObject (Variable "vector1" twoDymVectorAnn)) undefined
-vector3 = Declaration "vector3" Mutable vectorTS (VectorInitExpression uint32Const0 (KC (I UInt32 10)) vectorAnn) undefined
-vector4 = Declaration "vector4" Mutable twoDimVectorTS (VectorInitExpression (VectorInitExpression uint32Const0 (KC (I UInt32 5)) twoDymVectorRowAnn) (KC (I UInt32 10)) twoDymVectorAnn) undefined
-vector5 = Declaration "vector5" Mutable twoDimVectorTS (VectorInitExpression (AccessObject (Variable "vector_row" twoDymVectorRowAnn)) (KC (I UInt32 10)) twoDymVectorAnn) undefined
-vector6 = Declaration "vector6" Mutable vectorTMDescriptorTS (VectorInitExpression tmDescriptorFieldsInit0 (KC (I UInt32 10)) vectorTMDescriptorAnn) undefined
+vector3 = Declaration "vector3" Mutable vectorTS (VectorInitExpression uint32Const0 (K 10) vectorAnn) undefined
+vector4 = Declaration "vector4" Mutable twoDimVectorTS (VectorInitExpression (VectorInitExpression uint32Const0 (K 5) twoDymVectorRowAnn) (K 10) twoDymVectorAnn) undefined
+vector5 = Declaration "vector5" Mutable twoDimVectorTS (VectorInitExpression (AccessObject (Variable "vector_row" twoDymVectorRowAnn)) (K 10) twoDymVectorAnn) undefined
+vector6 = Declaration "vector6" Mutable vectorTMDescriptorTS (VectorInitExpression tmDescriptorFieldsInit0 (K 10) vectorTMDescriptorAnn) undefined
 
 foo0 :: Expression SemanticAnns
 foo0 = AccessObject (Variable "foo0" (objSemAnn Mutable UInt32))
@@ -63,7 +63,7 @@ structAFieldsInit0 :: Expression SemanticAnns
 structAFieldsInit0 = 
     FieldAssignmentsExpression "StructA"
         [FieldValueAssignment "field_a" uint32Const0,
-         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (KC (I UInt32 10)) vectorAnn),
+         FieldValueAssignment "field_b" (VectorInitExpression uint32Const0 (K 10) vectorAnn),
          FieldValueAssignment "field_c" uint32Const0xFFFF0000] structASemAnn
 
 tmDescriptorFieldsInit0 :: Expression SemanticAnns
@@ -145,7 +145,7 @@ spec = do
         "{\n" ++
         "    struct0.field0 = 0;\n" ++
         "    struct0.field1.field_a = 0;\n" ++
-        "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+        "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
         "        struct0.field1.field_b[__i0] = 0;\n" ++
         "    }\n" ++
         "    struct0.field1.field_c = 4294901760;\n" ++
@@ -160,7 +160,7 @@ spec = do
           "uint32_t vector1[10];\n" ++
           "\n" ++
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "        vector1[__i0] = vector0[__i0];\n" ++
           "    }\n" ++
           "}")
@@ -170,8 +170,8 @@ spec = do
           "int64_t vector2[10][5];\n" ++
           "\n" ++
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
           "            vector2[__i0][__i1] = vector1[__i0][__i1];\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -182,7 +182,7 @@ spec = do
           "uint32_t vector3[10];\n" ++
           "\n" ++
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "        vector3[__i0] = 0;\n" ++
           "    }\n" ++
           "}")
@@ -192,8 +192,8 @@ spec = do
           "int64_t vector4[10][5];\n" ++
           "\n" ++
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
           "            vector4[__i0][__i1] = 0;\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -204,8 +204,8 @@ spec = do
           "int64_t vector5[10][5];\n" ++
           "\n" ++
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 5; __i1 = __i1 + 1) {\n" ++
           "            vector5[__i0][__i1] = vector_row[__i1];\n" ++
           "        }\n" ++
           "    }\n" ++
@@ -217,10 +217,10 @@ spec = do
           "TMDescriptor vector6[20];\n" ++
           "\n" ++
           "{\n" ++
-          "    for (uint32_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
+          "    for (size_t __i0 = 0; __i0 < 10; __i0 = __i0 + 1) {\n" ++
           "        vector6[__i0].field0 = 0;\n" ++
           "        vector6[__i0].field1.field_a = 0;\n" ++
-          "        for (uint32_t __i1 = 0; __i1 < 10; __i1 = __i1 + 1) {\n" ++
+          "        for (size_t __i1 = 0; __i1 < 10; __i1 = __i1 + 1) {\n" ++
           "            vector6[__i0].field1.field_b[__i1] = 0;\n" ++
           "        }\n" ++
           "        vector6[__i0].field1.field_c = 4294901760;\n" ++

--- a/test/UT/PPrinter/TypeDef/ClassSpec.hs
+++ b/test/UT/PPrinter/TypeDef/ClassSpec.hs
@@ -30,7 +30,7 @@ classWithTwoProceduresAndZeroFields = TypeDefinition (Class ResourceClass "id0" 
     ] [] undefined,
     ClassProcedure "procedure1" [
       Parameter "param0" UInt8,
-      Parameter "param1" (Reference Mutable (Vector UInt8 (KC (I UInt32 32))))
+      Parameter "param1" (Reference Mutable (Vector UInt8 (K 32)))
     ] [] undefined
   ] []) undefined
 
@@ -43,7 +43,7 @@ classWithOneProcedureAndTwoFields :: AnnASTElement SemanticAnns
 classWithOneProcedureAndTwoFields = TypeDefinition
   (Class ResourceClass "id0" [
     ClassField (FieldDefinition "field0" UInt8) undefined,
-    ClassField (FieldDefinition "field1" (Vector UInt64 (KC (I UInt32 24)))) undefined,
+    ClassField (FieldDefinition "field1" (Vector UInt64 (K 24))) undefined,
     ClassProcedure "procedure0" [] [] undefined
   ] []) undefined
 
@@ -51,7 +51,7 @@ noHandlerClassWithOneEmptyProcedure :: AnnASTElement SemanticAnns
 noHandlerClassWithOneEmptyProcedure = TypeDefinition
   (Class ResourceClass "id0" [
     ClassField (FieldDefinition "field0" UInt8) undefined,
-    ClassField (FieldDefinition "field1" (Vector UInt64 (KC (I UInt32 24)))) undefined,
+    ClassField (FieldDefinition "field1" (Vector UInt64 (K 24))) undefined,
     ClassProcedure "procedure0" [] [] undefined
   ] [Modifier "no_handler" Nothing]) undefined
 
@@ -60,10 +60,10 @@ packedClass = TypeDefinition
   (Class ResourceClass "id0" [
     ClassField (FieldDefinition "field0" UInt64) undefined,
     ClassField (FieldDefinition "field1" UInt16) undefined,
-    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32)))) undefined,
+    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (K 32))) undefined,
     ClassProcedure "procedure0" [
       Parameter "param0" Char,
-      Parameter "param1" (Reference Mutable (Vector UInt8 (KC (I UInt32 16))))
+      Parameter "param1" (Reference Mutable (Vector UInt8 (K 16)))
     ] [] undefined
   ] [Modifier "packed" Nothing]) undefined
 
@@ -72,7 +72,7 @@ alignedClass = TypeDefinition
   (Class ResourceClass "id0" [
     ClassField (FieldDefinition "field0" UInt64) undefined,
     ClassField (FieldDefinition "field1" UInt16) undefined,
-    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32)))) undefined,
+    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (K 32))) undefined,
     ClassProcedure "procedure0" [] [] undefined
   ] [Modifier "align" (Just (KC (I UInt32 16)))]) undefined
 
@@ -81,7 +81,7 @@ packedAndAlignedClass = TypeDefinition
   (Class ResourceClass "id0" [
     ClassField (FieldDefinition "field0" UInt64) undefined,
     ClassField (FieldDefinition "field1" (DefinedType "TCDescriptor")) undefined,
-    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (KC (I UInt32 32)))) undefined,
+    ClassField (FieldDefinition "field2" (Vector (DefinedType "TMDescriptor") (K 32))) undefined,
     ClassProcedure "procedure0" [] [] undefined
   ] [
       Modifier "packed" Nothing,

--- a/test/UT/PPrinter/TypeDef/EnumSpec.hs
+++ b/test/UT/PPrinter/TypeDef/EnumSpec.hs
@@ -32,7 +32,7 @@ enumWithMultipleParameterizedFields = TypeDefinition
     EnumVariant "variant0" [UInt32],
     EnumVariant "variant1" [],
     EnumVariant "variant2" [UInt64, DefinedType "id1", Char],
-    EnumVariant "variant3" [Int8, Vector (Vector Char (KC (I UInt32 20))) (KC (I UInt32 35))]
+    EnumVariant "variant3" [Int8, Vector (Vector Char (K 20)) (K 35)]
   ] []) undefined
 
 renderTypedefDeclaration :: AnnASTElement SemanticAnns -> Text

--- a/test/UT/PPrinter/TypeDef/StructSpec.hs
+++ b/test/UT/PPrinter/TypeDef/StructSpec.hs
@@ -44,7 +44,7 @@ packedStruct = TypeDefinition
   (Struct "id0" [
     FieldDefinition "field0" UInt8,
     FieldDefinition "field1" UInt16,
-    FieldDefinition "field2" (Vector UInt32 (KC (I UInt32 10)))
+    FieldDefinition "field2" (Vector UInt32 (K 10))
   ] [Modifier "packed" Nothing]) undefined
 
 {- | Aligned Struct type.
@@ -61,7 +61,7 @@ alignedStruct = TypeDefinition
   (Struct "id0" [
     FieldDefinition "field0" UInt8,
     FieldDefinition "field1" UInt16,
-    FieldDefinition "field2" (Vector UInt32 (KC (I UInt32 10)))
+    FieldDefinition "field2" (Vector UInt32 (K 10))
   ] [Modifier "align" (Just (KC (I UInt32 16)))]) undefined
 
 {- | Aligned Struct type.
@@ -79,7 +79,7 @@ packedAndAlignedStruct = TypeDefinition
   (Struct "id0" [
     FieldDefinition "field0" UInt8,
     FieldDefinition "field1" UInt16,
-    FieldDefinition "field2" (Vector UInt32 (KC (I UInt32 10)))
+    FieldDefinition "field2" (Vector UInt32 (K 10))
   ] [
       Modifier "packed" Nothing,
       Modifier "align" (Just (KC (I UInt32 16)))


### PR DESCRIPTION
We have made the following changes:

- The definition of arrays has been changed so that the dimension is an integer constant with no type. This makes it necessary to recode existing code to remove the type from the dimension.
- A new unsigned integer type named `usize` (USize) has been added (à la Rust). This type is equivalent, and is transpiled directly, to the `size_t` type in C. This type is an unsigned integer of size equal to the size of the target machine addresses.
- The new type usize is the type now used to index all arrays and to create the slices. It is necessary to recode the existing code to adapt it to the new situation.

Currently, the bit size of the `usize` type is fixed at 32 bits, although the type itself is transpiled to `size_t`. In the future, it will be necessary to tell the transpiler the size of the `size_t` type for the target machine so that it can check the definition of the constants of that type.