### PR TITLE
Updated match statement pretty printing

### DIFF
--- a/src/PPrinter/Common.hs
+++ b/src/PPrinter/Common.hs
@@ -155,8 +155,10 @@ ppResourceClassIDField = pretty "__resource_id"
 ppTaskClassIDField = pretty "__task_id"
 ppHandlerClassIDField = pretty "__handler_id"
 
+-- | Pretty prints the name of the enum that defines the variants
+-- of the enumeration
 enumIdentifier :: Identifier -> DocStyle
-enumIdentifier identifier = pretty (namefy ("enum_" ++ identifier))
+enumIdentifier identifier = pretty (namefy ("enum_" ++ identifier ++ "_t"))
 
 -- |  Pretty prints the name of the field that will store the variant
 --  inside the struct corresponding to the enum.

--- a/test/IT/Global/PoolSpec.hs
+++ b/test/IT/Global/PoolSpec.hs
@@ -31,24 +31,28 @@ spec = do
     it "Prints declaration of Message type and external pool" $ do
       renderHeader test0 `shouldBe`
         pack ("typedef enum {\n" ++
-              "    In,\n" ++
-              "    Out,\n" ++
-              "    Stop,\n" ++
-              "    Reset\n" ++
-              "} __enum_Message;\n" ++
+              "    __Message_In,\n" ++
+              "    __Message_Out,\n" ++
+              "    __Message_Stop,\n" ++
+              "    __Message_Reset\n" ++
+              "} __enum_Message_t;\n" ++
+              "\n" ++
+              "typedef struct {\n" ++
+              "    uint32_t __0;\n" ++
+              "    uint32_t __1;\n" ++
+              "} __enum_Message_In_params_t;\n" ++
+              "\n" ++
+              "typedef struct {\n" ++
+              "    uint32_t __0;\n" ++
+              "} __enum_Message_Out_params_t;\n" ++
               "\n" ++
               "typedef struct {\n" ++
               "\n" ++
-              "    __enum_Message __variant;\n" ++
-              "    \n" ++
+              "    __enum_Message_t __variant;\n" ++
+              "\n" ++
               "    union {\n" ++
-              "        struct {\n" ++
-              "            uint32_t __0;\n" ++
-              "            uint32_t __1;\n" ++
-              "        } __In;\n" ++
-              "        struct {\n" ++
-              "            uint32_t __0;\n" ++
-              "        } __Out;\n" ++
+              "        __enum_Message_In_params_t __In;\n" ++
+              "        __enum_Message_Out_params_t __Out;\n" ++
               "    };\n" ++
               "\n" ++
               "} Message;\n" ++

--- a/test/IT/Statement/MatchSpec.hs
+++ b/test/IT/Statement/MatchSpec.hs
@@ -96,7 +96,9 @@ spec = do
               "\n" ++
               "    } else {\n" ++
               "\n" ++
-              "        ret = *((uint32_t *)option0.__Some.__0.data);\n" ++
+              "        __termina_option_dyn_t __option0__Some = option0.__Some;\n" ++
+              "\n" ++
+              "        ret = *((uint32_t *)__option0__Some.data);\n" ++
               "\n" ++
               "    }\n" ++
               "\n" ++
@@ -117,7 +119,9 @@ spec = do
               "        \n" ++
               "    } else {\n" ++
               "\n" ++
-              "        ret = *((uint32_t *)option0.__Some.__0.data);\n" ++
+              "        __termina_option_dyn_t __option0__Some = option0.__Some;\n" ++
+              "\n" ++
+              "        ret = *((uint32_t *)__option0__Some.data);\n" ++
               "\n" ++
               "    }\n" ++
               "\n" ++
@@ -127,24 +131,28 @@ spec = do
     it "Prints declaration of function match_test2" $ do
       renderHeader test2 `shouldBe`
         pack ("typedef enum {\n" ++
-              "    In,\n" ++
-              "    Out,\n" ++
-              "    Stop,\n" ++
-              "    Reset\n" ++
-              "} __enum_Message;\n" ++
+              "    __Message_In,\n" ++
+              "    __Message_Out,\n" ++
+              "    __Message_Stop,\n" ++
+              "    __Message_Reset\n" ++
+              "} __enum_Message_t;\n" ++
+              "\n" ++
+              "typedef struct {\n" ++
+              "    uint32_t __0;\n" ++
+              "    uint32_t __1;\n" ++
+              "} __enum_Message_In_params_t;\n" ++
+              "\n" ++
+              "typedef struct {\n" ++
+              "    uint32_t __0;\n" ++
+              "} __enum_Message_Out_params_t;\n" ++
               "\n" ++
               "typedef struct {\n" ++
               "\n" ++
-              "    __enum_Message __variant;\n" ++
-              "    \n" ++
+              "    __enum_Message_t __variant;\n" ++
+              "\n" ++
               "    union {\n" ++
-              "        struct {\n" ++
-              "            uint32_t __0;\n" ++
-              "            uint32_t __1;\n" ++
-              "        } __In;\n" ++
-              "        struct {\n" ++
-              "            uint32_t __0;\n" ++
-              "        } __Out;\n" ++
+              "        __enum_Message_In_params_t __In;\n" ++
+              "        __enum_Message_Out_params_t __Out;\n" ++
               "    };\n" ++
               "\n" ++
               "} Message;\n" ++
@@ -155,7 +163,8 @@ spec = do
         pack ("uint32_t match_test1() {\n" ++
               "\n" ++
               "    uint32_t ret = 0;\n" ++
-              "\n    Message msg;\n" ++
+              "\n" ++
+              "    Message msg;\n" ++
               "\n" ++
               "    {\n" ++
               "        msg.__variant = In;\n" ++
@@ -163,21 +172,25 @@ spec = do
               "        msg.__In.__1 = 10;\n" ++
               "    }\n" ++
               "\n" ++
-              "    if (msg.__variant == Stop) {\n" ++
+              "    if (msg.__variant == __Message_Stop) {\n" ++
               "\n" ++
               "        ret = 0;\n" ++
               "\n" ++
-              "    } else if (msg.__variant == Reset) {\n" ++
+              "    } else if (msg.__variant == __Message_Reset) {\n" ++
               "\n" ++
               "        ret = 1;\n" ++
               "\n" ++
-              "    } else if (msg.__variant == Out) {\n" ++
+              "    } else if (msg.__variant == __Message_Out) {\n" ++
               "\n" ++
-              "        ret = msg.__Out.__0;\n" ++
+              "        __enum_Message_Out_params_t __msg__Out = msg.__Out;\n" ++
+              "\n" ++
+              "        ret = __msg__Out.__0;\n" ++
               "\n" ++
               "    } else {\n" ++
               "\n" ++
-              "        ret = msg.__In.__0 + msg.__In.__1;\n" ++
+              "        __enum_Message_In_params_t __msg__In = msg.__In;\n" ++
+              "\n" ++
+              "        ret = __msg__In.__0 + __msg__In.__1;\n" ++
               "\n" ++
               "    }\n" ++
               "\n" ++

--- a/test/IT/TypeDef/TaskSpec.hs
+++ b/test/IT/TypeDef/TaskSpec.hs
@@ -62,26 +62,30 @@ spec = do
     it "Prints declaration of class TMChannel without no_handler" $ do
       renderHeader test0 `shouldBe`
         pack ("typedef enum {\n" ++
-              "    In,\n" ++
-              "    Out,\n" ++
-              "    Stop,\n" ++
-              "    Reset\n" ++
-              "} __enum_Message;\n" ++
+              "    __Message_In,\n" ++
+              "    __Message_Out,\n" ++
+              "    __Message_Stop,\n" ++
+              "    __Message_Reset\n" ++
+              "} __enum_Message_t;\n" ++
               "\n" ++
               "typedef struct {\n" ++
-              "\n" ++   
-              "    __enum_Message __variant;\n" ++
-              "    \n" ++       
+              "    uint32_t __0;\n" ++
+              "    uint32_t __1;\n" ++
+              "} __enum_Message_In_params_t;\n" ++
+              "\n" ++
+              "typedef struct {\n" ++
+              "    uint32_t __0;\n" ++
+              "} __enum_Message_Out_params_t;\n" ++
+              "\n" ++
+              "typedef struct {\n" ++
+              "\n" ++
+              "    __enum_Message_t __variant;\n" ++
+              "\n" ++
               "    union {\n" ++
-              "        struct {\n" ++
-              "            uint32_t __0;\n" ++
-              "            uint32_t __1;\n" ++
-              "        } __In;\n" ++
-              "        struct {\n" ++
-              "            uint32_t __0;\n" ++
-              "        } __Out;\n" ++
+              "        __enum_Message_In_params_t __In;\n" ++
+              "        __enum_Message_Out_params_t __Out;\n" ++
               "    };\n" ++
-              "\n" ++   
+              "\n" ++
               "} Message;\n" ++
               "\n" ++   
               "typedef struct {\n" ++
@@ -116,7 +120,9 @@ spec = do
               "        \n"  ++           
               "    } else {\n" ++
               "\n" ++   
-              "        __termina_pool_free(alloc_msg.__Some.__0);\n" ++
+              "        __termina_option_dyn_t __alloc_msg__Some = alloc_msg.__Some;\n" ++
+              "\n" ++
+              "        __termina_pool_free(__alloc_msg__Some);\n" ++
               "\n" ++  
               "    }\n" ++
               "\n" ++   

--- a/test/UT/PPrinter/Statement/MatchSpec.hs
+++ b/test/UT/PPrinter/Statement/MatchSpec.hs
@@ -83,7 +83,9 @@ spec = do
         pack (
           "if (option_var.__variant == Some) {\n" ++
           "\n" ++
-          "    foo1 = *((uint32_t *)option_var.__Some.__0.data);\n" ++
+          "    __termina_option_dyn_t __option_var__Some = option_var.__Some;\n" ++
+          "\n" ++
+          "    foo1 = *((uint32_t *)__option_var__Some.data);\n" ++
           "\n" ++
           "} else {\n" ++
           "\n" ++
@@ -99,7 +101,9 @@ spec = do
           "\n" ++
           "} else {\n" ++
           "\n" ++
-          "    foo1 = ((uint32_t *)option_var.__Some.__0.data)[8];\n" ++
+          "    __termina_option_dyn_t __option_var__Some = option_var.__Some;\n" ++
+          "\n" ++
+          "    foo1 = ((uint32_t *)__option_var__Some.data)[8];\n" ++
           "\n" ++
           "}")
     it "Prints a match option statement with a complex expression" $ do
@@ -110,7 +114,7 @@ spec = do
           "\n" ++
           "    if (__match.__variant == Some) {\n" ++
           "\n" ++
-          "        foo1 = *((uint32_t *)__match.__Some.__0.data);\n" ++
+          "        foo1 = *((uint32_t *)__match.__Some.data);\n" ++
           "\n" ++
           "    } else {\n" ++
           "\n" ++

--- a/test/UT/PPrinter/TypeDef/EnumSpec.hs
+++ b/test/UT/PPrinter/TypeDef/EnumSpec.hs
@@ -45,42 +45,44 @@ spec = do
       renderTypedefDeclaration enumWithOneRegularField `shouldBe`
         pack (
             "typedef enum {\n" ++
-            "    variant0\n" ++
-            "} __enum_id0;\n" ++
+            "    __id0_variant0\n" ++
+            "} __enum_id0_t;\n" ++
             "\n" ++
             "typedef struct {\n" ++
             "\n" ++
-            "    __enum_id0 __variant;\n" ++
+            "    __enum_id0_t __variant;\n" ++
             "\n" ++
             "} id0;\n")
     it "Prints an enum with two regular variants" $ do
       renderTypedefDeclaration enumWithTwoRegularFields `shouldBe`
         pack (
             "typedef enum {\n" ++
-            "    variant0,\n" ++
-            "    variant1\n" ++
-            "} __enum_id0;\n" ++
+            "    __id0_variant0,\n" ++
+            "    __id0_variant1\n" ++
+            "} __enum_id0_t;\n" ++
             "\n" ++
             "typedef struct {\n" ++
             "\n" ++
-            "    __enum_id0 __variant;\n" ++
+            "    __enum_id0_t __variant;\n" ++
             "\n" ++
             "} id0;\n")
     it "Prints an enum with one parameterized variant" $ do
       renderTypedefDeclaration enumWithOneParameterizedField `shouldBe`
         pack (
             "typedef enum {\n" ++
-            "    variant0\n" ++
-            "} __enum_id0;\n" ++
+            "    __id0_variant0\n" ++
+            "} __enum_id0_t;\n" ++
+            "\n" ++
+            "typedef struct {\n" ++
+            "    uint32_t __0;\n" ++
+            "} __enum_id0_variant0_params_t;\n" ++
             "\n" ++
             "typedef struct {\n" ++
             "\n" ++
-            "    __enum_id0 __variant;\n" ++
-            "    \n" ++
+            "    __enum_id0_t __variant;\n" ++
+            "\n" ++
             "    union {\n" ++
-            "        struct {\n" ++
-            "            uint32_t __0;\n" ++
-            "        } __variant0;\n" ++
+            "        __enum_id0_variant0_params_t __variant0;\n" ++
             "    };\n" ++
             "\n" ++
             "} id0;\n")
@@ -88,29 +90,35 @@ spec = do
       renderTypedefDeclaration enumWithMultipleParameterizedFields `shouldBe`
         pack (
             "typedef enum {\n" ++
-            "    variant0,\n" ++
-            "    variant1,\n" ++
-            "    variant2,\n" ++
-            "    variant3\n" ++
-            "} __enum_id0;\n" ++
+            "    __id0_variant0,\n" ++
+            "    __id0_variant1,\n" ++
+            "    __id0_variant2,\n" ++
+            "    __id0_variant3\n" ++
+            "} __enum_id0_t;\n" ++
+            "\n" ++
+            "typedef struct {\n" ++
+            "    uint32_t __0;\n" ++
+            "} __enum_id0_variant0_params_t;\n" ++
+            "\n" ++
+            "typedef struct {\n" ++
+            "    uint64_t __0;\n" ++
+            "    id1 __1;\n" ++
+            "    char __2;\n" ++
+            "} __enum_id0_variant2_params_t;\n" ++
+            "\n" ++
+            "typedef struct {\n" ++
+            "    int8_t __0;\n" ++
+            "    char __1[35][20];\n" ++
+            "} __enum_id0_variant3_params_t;\n" ++
             "\n" ++
             "typedef struct {\n" ++
             "\n" ++
-            "    __enum_id0 __variant;\n" ++
-            "    \n" ++
+            "    __enum_id0_t __variant;\n" ++
+            "\n" ++
             "    union {\n" ++
-            "        struct {\n" ++
-            "            uint32_t __0;\n" ++
-            "        } __variant0;\n" ++
-            "        struct {\n" ++
-            "            uint64_t __0;\n" ++
-            "            id1 __1;\n" ++
-            "            char __2;\n" ++
-            "        } __variant2;\n" ++
-            "        struct {\n" ++
-            "            int8_t __0;\n" ++
-            "            char __1[35][20];\n" ++
-            "        } __variant3;\n" ++
+            "        __enum_id0_variant0_params_t __variant0;\n" ++
+            "        __enum_id0_variant2_params_t __variant2;\n" ++
+            "        __enum_id0_variant3_params_t __variant3;\n" ++
             "    };\n" ++
             "\n" ++
             "} id0;\n");


### PR DESCRIPTION
The code of the match statement cases with associated parameters was not generated correctly. In non-anonymous match statements, i.e. where the expression was an object, the case accessed the object fields directly instead of making a copy. This could cause a problem if the value of the original object was overwritten. Now, in the case of non-anonymous match statements, a copy is made when entering the corresponding case.

All tests pass.