### PR TITLE
Added DereferenceMemberAccess element

### DIFF
--- a/src/AST/Core.hs
+++ b/src/AST/Core.hs
@@ -291,6 +291,8 @@ data Expression'
   | FunctionExpression Identifier [ Expression' obj a ] a
   | MemberFunctionAccess (obj a) Identifier [Expression' obj a] a
   -- ^ Class method access | eI.name(x_{1}, ... , x_{n})|
+  | DerefMemberFunctionAccess (obj a) Identifier [Expression' obj a] a
+  -- ^ Dereference class method/viewer access | self->name(x_{1}, ... , x_{n})|
   --
   -- These four constructors cannot be used on regular (primitive?) expressions
   -- These two can only be used as the RHS of an assignment:
@@ -312,14 +314,15 @@ instance (Annotated obj) => Annotated (Expression' obj) where
   getAnnotation (AccessObject obj)                       = getAnnotation obj
   getAnnotation (Constant _ a)                           = a
   getAnnotation (BinOp _ _ _ a)                          = a
-  getAnnotation (ReferenceExpression _ _ a)                = a
+  getAnnotation (ReferenceExpression _ _ a)              = a
   getAnnotation (Casting _ _ a)                          = a
   getAnnotation (FunctionExpression _ _ a)               = a
-  getAnnotation (FieldAssignmentsExpression _ _ a) = a
+  getAnnotation (FieldAssignmentsExpression _ _ a)       = a
   getAnnotation (EnumVariantExpression _ _ _ a)          = a
   getAnnotation (VectorInitExpression _ _ a)             = a
   getAnnotation (OptionVariantExpression _ a)            = a
-  getAnnotation (MemberFunctionAccess _ _ _ a)             = a
+  getAnnotation (MemberFunctionAccess _ _ _ a)           = a
+  getAnnotation (DerefMemberFunctionAccess _ _ _ a)      = a
 
 
 data Statement' expr obj a =

--- a/src/PPrinter/Statement.hs
+++ b/src/PPrinter/Statement.hs
@@ -70,7 +70,7 @@ ppMatchCase subs (Named obj) (Option {}) (MatchCase "Some" [sym] body _) =
 ppMatchCase subs _ (DefinedType _) (MatchCase _ [] body _) =
     vsep $ [ ppStatement subs s <> line | s <- body ]
 ppMatchCase subs Annonymous (DefinedType _) (MatchCase variant params body _) =
-    let variable = pretty (namefy ("match." ++ (namefy variant)))
+    let variable = pretty (namefy ("match." ++ namefy variant))
         -- | New map of substitutions. This map contains the substitutions
         -- of the parameters of the match case. It maps each parameter
         -- identifier to the corresponding field of the enumeration variant's

--- a/src/Parser/Parsing.hs
+++ b/src/Parser/Parsing.hs
@@ -523,8 +523,10 @@ accessObjectParser = accessObjectParser' (AccessObject <$> objectTermParser)
       _ <- reservedOp "->"
       p <- getPosition
       member <- identifierParser
+      params <- optionMaybe (parens (sepBy (try expressionParser) comma))
       return (\parent -> case parent of
-        AccessObject obj -> AccessObject (DereferenceMemberAccess obj member (Position p))
+        AccessObject obj ->
+          maybe (AccessObject (DereferenceMemberAccess obj member (Position p))) (flip (DerefMemberFunctionAccess obj member) (Position p)) params
         _ -> error "Unexpected member access to a non object"))
     memberAccessPostfix
       = Ex.Postfix (do

--- a/test/IT/TypeDef/TaskSpec.hs
+++ b/test/IT/TypeDef/TaskSpec.hs
@@ -19,6 +19,14 @@ test0 = "enum Message {\n" ++
         "  interval : u32;\n" ++
         "  message_pool : port Pool<Message; 10>;\n" ++
         "\n" ++
+        "  viewer check_interval(&self, limit : u32) -> bool {\n" ++ 
+        "    var ret : bool = true;\n" ++     
+        "    if (self->interval > limit) {\n" ++
+        "      ret = false;\n" ++
+        "    }\n" ++
+        "    return ret;\n" ++
+        "  }\n" ++
+        "\n" ++
         "  method run(&priv self) -> TaskRet {\n" ++
         "\n" ++        
         "    var ret : TaskRet = TaskRet::Continue;\n" ++
@@ -33,6 +41,12 @@ test0 = "enum Message {\n" ++
         "        }\n" ++
         "        case None => {\n" ++
         "        }\n" ++
+        "    }\n" ++
+        "\n" ++
+        "    var check : bool = (*self).check_interval(10 : u32);\n" ++
+        "\n" ++
+        "    if (check == false) {\n" ++
+        "      ret = TaskRet::Abort;\n" ++
         "    }\n" ++
         "\n" ++
         "    return ret;\n" ++
@@ -94,7 +108,9 @@ spec = do
               "    __termina_task_id_t __task_id;\n" ++
               "} CHousekeeping;\n" ++
               "\n" ++   
-              "TaskRet __CHousekeeping_run(CHousekeeping * self);\n")
+              "TaskRet __CHousekeeping_run(CHousekeeping * self);\n" ++
+              "\n" ++
+              "_Bool check_interval(CHousekeeping * self, uint32_t limit);\n")
     it "Prints definition of class TMChannel without no_handler" $ do
       renderSource test0 `shouldBe`
         pack ("TaskRet __CHousekeeping_run(CHousekeeping * self) {\n" ++
@@ -125,7 +141,32 @@ spec = do
               "        __termina_pool_free(__alloc_msg__Some);\n" ++
               "\n" ++  
               "    }\n" ++
+              "\n" ++
+              "    _Bool check = __CHousekeeping_check_interval(self, 10);\n" ++
+              "\n" ++
+              "    if (check == 0) {\n" ++
+              "\n" ++
+              "        {\n" ++
+              "            ret.__variant = Abort;\n" ++
+              "        }\n" ++
+              "\n" ++
+              "    }\n" ++
               "\n" ++   
               "    return ret;\n" ++
               "\n" ++   
+              "}\n" ++
+              "\n" ++
+              "\n" ++
+              "_Bool __CHousekeeping_check_interval(CHousekeeping * self, uint32_t limit) {\n" ++
+              "\n" ++
+              "    _Bool ret = 1;\n" ++
+              "\n" ++
+              "    if (self->interval > limit) {\n" ++
+              "\n" ++
+              "        ret = 0;\n" ++
+              "\n" ++
+              "    }\n" ++
+              "\n" ++
+              "    return ret;\n" ++
+              "\n" ++
               "}\n\n")

--- a/test/UT/PPrinter/Expression/MemberFunctionAccessSpec.hs
+++ b/test/UT/PPrinter/Expression/MemberFunctionAccessSpec.hs
@@ -19,9 +19,12 @@ bar1 = Variable "bar1" dynUInt16SemAnn
 tmPoolAlloc :: Expression SemanticAnns
 tmPoolAlloc = MemberFunctionAccess tmPool "alloc" [] unitSemAnn
 
+selfDereference :: Object SemanticAnns
+selfDereference = Dereference self (definedTypeSemAnn Private "Resource")
+
 tmChannelsend, selfFoo0 :: Expression SemanticAnns
 tmChannelsend = MemberFunctionAccess tmChannel "send" [AccessObject bar0] unitSemAnn
-selfFoo0 = MemberFunctionAccess self "foo0" [AccessObject bar0, AccessObject bar1] unitSemAnn
+selfFoo0 = MemberFunctionAccess selfDereference "foo0" [AccessObject bar0, AccessObject bar1] unitSemAnn
 
 renderExpression :: Expression SemanticAnns -> Text
 renderExpression = render . ppExpression empty
@@ -35,6 +38,6 @@ spec = do
     it "Prints the expression: tm_channel.foo0(bar0)" $ do
       renderExpression tmChannelsend `shouldBe`
         pack "__termina_msg_queue_send(tm_channel, bar0)"
-    it "Prints the expression: resource.foo0(bar0, bar1)" $ do
+    it "Prints the expression: (*self).foo0(bar0, bar1)" $ do
       renderExpression selfFoo0 `shouldBe`
         pack "__Resource_foo0(self, bar0, bar1)"


### PR DESCRIPTION
The DereferenceMemberAccess AST element has been added, corresponding to the `->` operator used to call the methods or viewers of a class from a reference. This operator is only used to call the methods of the class itself from its `self` reference, since in the case of procedure calls, they are made through a port.

The type checker code has been minimally restructured to avoid duplicity in the code.

New tests have been added to test the new AST element.