### PR TITLE
Minor fixes and example application

### DIFF
--- a/examples/sample_app_01/app.fin
+++ b/examples/sample_app_01/app.fin
@@ -1,0 +1,11 @@
+import { tasks.housekeeping, drivers.uart }
+
+resource uart0 : UARTDriver = { 
+    initialized = false,
+    status_register @ 0x80000100
+} : UARTDriver;
+
+task housekeeping_task : CHouseKeepingTask = { 
+    uart <- uart0,
+    count = 0 : u32
+} : CHouseKeepingTask;

--- a/examples/sample_app_01/drivers/uart.fin
+++ b/examples/sample_app_01/drivers/uart.fin
@@ -1,0 +1,15 @@
+
+resource class UARTDriver {
+
+    initialized : bool;
+    status_register : loc u32;
+
+    procedure init(&priv self) {
+
+        self->initialized = true;
+
+        return;
+
+    }
+
+};

--- a/examples/sample_app_01/tasks/housekeeping/src.fin
+++ b/examples/sample_app_01/tasks/housekeeping/src.fin
@@ -1,0 +1,23 @@
+import { drivers.uart }
+
+task class CHouseKeepingTask {
+
+    uart : port UARTDriver;
+
+    count : u32;
+
+    viewer is_count_zero(&self) -> bool {
+        return self->count == 0 : u32;
+    }
+
+    method run(&priv self) -> TaskRet {
+
+        var ret : TaskRet = TaskRet::Continue;
+
+        self->uart.init();
+
+        return ret;
+
+    }
+
+};

--- a/src/PPrinter/TypeDef.hs
+++ b/src/PPrinter/TypeDef.hs
@@ -39,7 +39,7 @@ ppClassProcedureOnExit :: DocStyle
 ppClassProcedureOnExit = ppCFunctionCall resourceUnlock [pretty "self->__resource_id"] <> semi
 
 ppSelfParameter :: Identifier -> DocStyle
-ppSelfParameter classId = pretty classId <+> pretty "*" <+> pretty "self"
+ppSelfParameter classId = pretty classId <+> pretty "*" <+> pretty "const" <+> pretty "self"
 
 ppClassFunctionDefinition :: Identifier -> ClassMember SemanticAnns -> DocStyle
 ppClassFunctionDefinition classId (ClassProcedure identifier parameters blk _) =
@@ -75,7 +75,7 @@ ppClassFunctionDefinition classId (ClassViewer identifier parameters rts body _)
     ppCFunctionPrototype (classFunctionName classId identifier)
       (
         -- | Print the self parameter
-        ppSelfParameter classId :
+        pretty "const" <+> ppSelfParameter classId :
         -- | Print the rest of the function parameters
         (ppParameterDeclaration (classFunctionName classId identifier) <$> parameters)
       )
@@ -121,7 +121,7 @@ ppClassFunctionDeclaration classId (ClassViewer identifier parameters rts _ _) =
     _ -> []) ++
   [
     ppCFunctionPrototype (pretty identifier)
-      (ppSelfParameter classId : (ppParameterDeclaration (pretty identifier) <$> parameters))
+      (pretty "const" <+> ppSelfParameter classId : (ppParameterDeclaration (pretty identifier) <$> parameters))
       (Just (ppReturnType (pretty identifier) rts)) <> semi,
     emptyDoc
   ]

--- a/test/IT/TypeDef/ResourceSpec.hs
+++ b/test/IT/TypeDef/ResourceSpec.hs
@@ -60,7 +60,8 @@ spec = do
               "    __termina_resource_t __resource_id;\n" ++
               "} TMChannel;\n" ++
               "\n" ++
-              "void __TMChannel_get_tm_sent_packets(TMChannel * self, uint32_t * packets);\n" ++
+              "void __TMChannel_get_tm_sent_packets(TMChannel * const self,\n" ++
+              "                                     uint32_t * packets);\n" ++
               "\n" ++
               "#endif // __TEST_H__\n")
     it "Prints definition of class TMChannel without no_handler" $ do
@@ -68,7 +69,8 @@ spec = do
         pack ("\n" ++
               "#include \"test.h\"\n" ++
               "\n" ++ 
-              "void __TMChannel_get_tm_sent_packets(TMChannel * self, uint32_t * packets) {\n" ++
+              "void __TMChannel_get_tm_sent_packets(TMChannel * const self,\n" ++
+              "                                     uint32_t * packets) {\n" ++
               "\n" ++
               "    __termina_resource_lock(self->__resource_id);\n" ++
               "\n" ++
@@ -91,7 +93,7 @@ spec = do
               "    __termina_resource_t __resource_id;\n" ++
               "} UARTDriver;\n" ++
               "\n" ++
-              "void __UARTDriver_get_status(UARTDriver * self, uint32_t * ret);\n" ++
+              "void __UARTDriver_get_status(UARTDriver * const self, uint32_t * ret);\n" ++
               "\n" ++
               "#endif // __TEST_H__\n")
     it "Prints definition of class UARTDriver" $ do
@@ -99,7 +101,7 @@ spec = do
         pack ("\n" ++
               "#include \"test.h\"\n" ++
               "\n" ++ 
-              "void __UARTDriver_get_status(UARTDriver * self, uint32_t * ret) {\n" ++
+              "void __UARTDriver_get_status(UARTDriver * const self, uint32_t * ret) {\n" ++
               "\n" ++
               "    __termina_resource_lock(self->__resource_id);\n" ++
               "\n" ++

--- a/test/IT/TypeDef/TaskSpec.hs
+++ b/test/IT/TypeDef/TaskSpec.hs
@@ -113,9 +113,9 @@ spec = do
               "    __termina_task_t __task_id;\n" ++
               "} CHousekeeping;\n" ++
               "\n" ++   
-              "TaskRet __CHousekeeping_run(CHousekeeping * self);\n" ++
+              "TaskRet __CHousekeeping_run(CHousekeeping * const self);\n" ++
               "\n" ++
-              "_Bool check_interval(CHousekeeping * self, uint32_t limit);\n" ++
+              "_Bool check_interval(const CHousekeeping * const self, uint32_t limit);\n" ++
               "\n" ++
               "#endif // __TEST_H__\n")
     it "Prints definition of class TMChannel without no_handler" $ do
@@ -123,7 +123,7 @@ spec = do
         pack ("\n" ++
               "#include \"test.h\"\n" ++
               "\n" ++ 
-              "TaskRet __CHousekeeping_run(CHousekeeping * self) {\n" ++
+              "TaskRet __CHousekeeping_run(CHousekeeping * const self) {\n" ++
               "\n" ++
               "    TaskRet ret;\n" ++
               "\n" ++
@@ -161,7 +161,8 @@ spec = do
               "}\n" ++
               "\n" ++
               "\n" ++
-              "_Bool __CHousekeeping_check_interval(CHousekeeping * self, uint32_t limit) {\n" ++
+              "_Bool __CHousekeeping_check_interval(const CHousekeeping * const self,\n" ++
+              "                                     uint32_t limit) {\n" ++
               "\n" ++
               "    _Bool ret = 1;\n" ++
               "\n" ++

--- a/test/UT/PPrinter/TypeDef/ClassSpec.hs
+++ b/test/UT/PPrinter/TypeDef/ClassSpec.hs
@@ -109,7 +109,7 @@ spec = do
           "    __termina_resource_t __resource_id;\n" ++
           "} id0;\n" ++
           "\n" ++
-          "void __id0_procedure0(id0 * self, uint8_t param0, uint16_t param1,\n" ++
+          "void __id0_procedure0(id0 * const self, uint8_t param0, uint16_t param1,\n" ++
           "                      uint32_t param2, uint64_t param3, int8_t param4,\n" ++
           "                      int16_t param5, int32_t param6, int64_t param7);\n")
     it "Prints a class with two procedures and zero fields" $ do
@@ -119,10 +119,10 @@ spec = do
           "    __termina_resource_t __resource_id;\n" ++
           "} id0;\n" ++
           "\n" ++
-          "void __id0_procedure0(id0 * self, uint8_t param0,\n" ++
+          "void __id0_procedure0(id0 * const self, uint8_t param0,\n" ++
           "                      __termina_option_dyn_t param1);\n" ++
           "\n" ++
-          "void __id0_procedure1(id0 * self, uint8_t param0, uint8_t param1[32]);\n")
+          "void __id0_procedure1(id0 * const self, uint8_t param0, uint8_t param1[32]);\n")
     it "Prints a class marked as no_handler with one procedure and zero fields" $ do
       renderTypedefDeclaration noHandlerClassWithoutOneProcedureAndZeroFields `shouldBe`
         pack (
@@ -130,7 +130,7 @@ spec = do
             "    __termina_resource_t __resource_id;\n" ++
             "} id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(id0 * self);\n")
+            "void __id0_procedure0(id0 * const self);\n")
     it "Prints a class marked as no_handler with two fields" $ do
       renderTypedefDeclaration noHandlerClassWithOneEmptyProcedure `shouldBe`
         pack (
@@ -140,7 +140,7 @@ spec = do
             "    __termina_resource_t __resource_id;\n" ++
             "} id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(id0 * self);\n")
+            "void __id0_procedure0(id0 * const self);\n")
     it "Prints a class with one procedure and two fields" $ do
       renderTypedefDeclaration classWithOneProcedureAndTwoFields `shouldBe`
         pack (
@@ -150,7 +150,7 @@ spec = do
             "    __termina_resource_t __resource_id;\n" ++
             "} id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(id0 * self);\n")
+            "void __id0_procedure0(id0 * const self);\n")
     it "Prints a packed class" $ do
       renderTypedefDeclaration packedClass `shouldBe`
         pack (
@@ -161,7 +161,7 @@ spec = do
             "    __termina_resource_t __resource_id;\n" ++
             "} __attribute__((packed)) id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(id0 * self, char param0, uint8_t param1[16]);\n")
+            "void __id0_procedure0(id0 * const self, char param0, uint8_t param1[16]);\n")
     it "Prints an aligned class" $ do
       renderTypedefDeclaration alignedClass `shouldBe`
         pack (
@@ -172,7 +172,7 @@ spec = do
             "    __termina_resource_t __resource_id;\n" ++
             "} __attribute__((align(16))) id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(id0 * self);\n")
+            "void __id0_procedure0(id0 * const self);\n")
     it "Prints a packed & aligned class" $ do
       renderTypedefDeclaration packedAndAlignedClass `shouldBe`
         pack (
@@ -183,7 +183,7 @@ spec = do
             "    __termina_resource_t __resource_id;\n" ++
             "} __attribute__((packed, align(16))) id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(id0 * self);\n")
+            "void __id0_procedure0(id0 * const self);\n")
     it "Prints a class with a fixed location field" $ do
       renderTypedefDeclaration classWithFixedLocationField `shouldBe`
         pack (
@@ -193,4 +193,4 @@ spec = do
             "    __termina_resource_t __resource_id;\n" ++
             "} id0;\n" ++
             "\n" ++
-            "void __id0_procedure0(id0 * self);\n")
+            "void __id0_procedure0(id0 * const self);\n")


### PR DESCRIPTION
This commit applies the following changes:

- Minor modification to pretty printer to remove unnecessary blank lines (`line` -> `emptyDoc`).
- Fixed parsing of expressions for field assignment. Parsing of constant addresses was not working properly because it did not take into account the possibility of whitespace after the address.
- Modules identifiers parsing has been modified to adapt them to the naming rules (snake case).
- Minor changes in the generation of class prototypes. Now, the self field is always a constant pointer that, in the case of viewers, also points to constant data.
- The functions of the type checker that obtained the objects from the environment have been modified. Now, when checking the initialization of global variables, global data can be used in the initialization (e.g. to be able to correctly assign resources to ports).
- Initial commit of of `sample_app_01`.

The tests have been adapted to the new changes in the printer. All tests pass.