### PR TITLE
Generation of the initialization function of global objects

### DIFF
--- a/src/AST/Core.hs
+++ b/src/AST/Core.hs
@@ -250,8 +250,8 @@ data Parameter = Parameter {
 
 data FieldAssignment' expr a =
   FieldValueAssignment Identifier (expr a)
-  | FieldAddressAssignment Identifier Address
-  | FieldPortConnection Identifier Identifier
+  | FieldAddressAssignment Identifier Address a
+  | FieldPortConnection Identifier Identifier a
   deriving (Show, Functor)
 
 data FieldDefinition = FieldDefinition {

--- a/src/PPrinter.hs
+++ b/src/PPrinter.hs
@@ -13,7 +13,8 @@ import Prettyprinter.Render.Terminal
 import Data.Text (Text, pack, intercalate, replace, toUpper)
 
 import PPrinter.Common
-import PPrinter.TypeDef
+import PPrinter.TypeDef.Declaration
+import PPrinter.TypeDef.Definition
 import Semantic.Monad (SemanticAnns)
 import PPrinter.Function
 import Data.Maybe
@@ -28,6 +29,8 @@ ppEmptyDoc = const emptyDoc
 ppHeaderASTElement :: AnnASTElement SemanticAnns -> Maybe DocStyle
 ppHeaderASTElement (TypeDefinition t _) = Just (ppTypeDefDeclaration t)
 ppHeaderASTElement (GlobalDeclaration obj@(Resource {})) = Just (ppGlobalDeclaration obj)
+ppHeaderASTElement (GlobalDeclaration obj@(Task {})) = Just (ppGlobalDeclaration obj)
+ppHeaderASTElement (GlobalDeclaration obj@(Handler {})) = Just (ppGlobalDeclaration obj)
 ppHeaderASTElement func@(Function {}) = Just (ppFunctionDeclaration func)
 ppHeaderASTElement _ = Nothing
 
@@ -35,6 +38,9 @@ ppSourceASTElement :: AnnASTElement SemanticAnns -> Maybe DocStyle
 ppSourceASTElement (TypeDefinition (Struct {}) _) = Nothing
 ppSourceASTElement (TypeDefinition (Enum {}) _) = Nothing
 ppSourceASTElement (TypeDefinition cls@(Class {}) _) = Just (ppClassDefinition cls)
+ppSourceASTElement (GlobalDeclaration obj@(Resource {})) = Just (ppGlobalDefinition obj)
+ppSourceASTElement (GlobalDeclaration obj@(Task {})) = Just (ppGlobalDefinition obj)
+ppSourceASTElement (GlobalDeclaration obj@(Handler {})) = Just (ppGlobalDefinition obj)
 ppSourceASTElement func@(Function {}) = Just (ppFunction func)
 ppSourceASTElement _ = Nothing
 

--- a/src/PPrinter/Application/Initialization.hs
+++ b/src/PPrinter/Application/Initialization.hs
@@ -1,0 +1,42 @@
+module PPrinter.Application.Initialization where
+
+import Semantic.Monad (SemanticAnns)
+import AST.Seman
+import PPrinter.Common
+import Prettyprinter
+import Data.Map (empty)
+import PPrinter.Statement.VariableInitialization
+import Modules.Modules
+import Modules.Printing
+
+
+ppInitializeObj :: Global SemanticAnns -> DocStyle
+-- Print only the elements that are not nothing
+ppInitializeObj (Resource identifier _ (Just expr) _ _) = 
+    ppInitializeStruct empty 0 (pretty identifier) expr
+ppInitializeObj (Task identifier _ (Just expr) _ _) = 
+    ppInitializeStruct empty 0 (pretty identifier) expr
+ppInitializeObj (Handler identifier _ (Just expr) _ _) = 
+    ppInitializeStruct empty 0 (pretty identifier) expr
+ppInitializeObj decl = error $ "unsupported global declaration: " ++ show decl
+
+ppInitFile :: [(ModuleName, [Global SemanticAnns])] -> DocStyle
+ppInitFile globals = 
+    -- | Set of the first elements of the globals
+    vsep $ [
+        pretty "#include <termina.h>",
+        emptyDoc
+    ] ++
+    map (\nm -> pretty "#include" <+> dquotes(ppModuleName nm <> pretty ".h")) (map fst glbs) ++ [emptyDoc] ++
+    [
+        ppCFunctionPrototype (pretty "__initialize_globals") [] Nothing <+> 
+        braces' (line <>
+            (indentTab . align $
+                vsep (
+                    concatMap (map (\o -> ppInitializeObj o)) [objs | (_, objs) <- globals]
+                )
+            ) <> line
+        ) <> line
+    ]
+    where
+        glbs = filter (\(_, objs) -> not (null objs)) globals

--- a/src/PPrinter/Global.hs
+++ b/src/PPrinter/Global.hs
@@ -2,10 +2,18 @@ module PPrinter.Global where
 
 import Prettyprinter
 
-import AST.Seman ( Global'(Resource), Global )
+import AST.Seman
 import PPrinter.Common
 import Semantic.Monad (SemanticAnns)
 
 ppGlobalDeclaration :: Global SemanticAnns -> DocStyle
 ppGlobalDeclaration (Resource identifier ts _ _ _) = externC <+> ppTypeSpecifier ts <+> pretty identifier <> ppDimension ts <> semi <> line
+ppGlobalDeclaration (Task identifier ts _ _ _) = externC <+> ppTypeSpecifier ts <+> pretty identifier <> ppDimension ts <> semi <> line
+ppGlobalDeclaration (Handler identifier ts _ _ _) = externC <+> ppTypeSpecifier ts <+> pretty identifier <> ppDimension ts <> semi <> line
 ppGlobalDeclaration decl = error $ "unsupported global declaration: " ++ show decl
+
+ppGlobalDefinition :: Global SemanticAnns -> DocStyle
+ppGlobalDefinition (Resource identifier ts _ _ _) = ppTypeSpecifier ts <+> pretty identifier <> ppDimension ts <> semi <> line
+ppGlobalDefinition (Task identifier ts _ _ _) = ppTypeSpecifier ts <+> pretty identifier <> ppDimension ts <> semi <> line
+ppGlobalDefinition (Handler identifier ts _ _ _) = ppTypeSpecifier ts <+> pretty identifier <> ppDimension ts <> semi <> line
+ppGlobalDefinition decl = error $ "unsupported global declaration: " ++ show decl

--- a/src/PPrinter/Statement/VariableInitialization.hs
+++ b/src/PPrinter/Statement/VariableInitialization.hs
@@ -113,7 +113,11 @@ ppInitializeStruct subs level target expr =
     -- \| This function can only be called with a field values assignments expressions
     (FieldAssignmentsExpression _ vas _) ->
         vsep $
-            map (\(FieldValueAssignment field expr') -> ppFieldInitializer subs level target (pretty field) expr') vas
+            map (\a -> case a of
+              FieldValueAssignment field expr' -> ppFieldInitializer subs level target (pretty field) expr'
+              FieldAddressAssignment field addr (SemAnn _ (ETy (SimpleType ts))) -> target <> pretty "." <> (pretty field) <+> pretty "=" <+> parens (ppTypeSpecifier ts) <> pretty addr <> semi
+              FieldPortConnection field res _ -> target <> pretty "." <> (pretty field) <+> pretty "=" <+> ppCReferenceExpression (pretty res)
+              _ -> error $ "Incorrect annotated assignment expression: " ++ show a) vas
     _ -> error $ "Incorrect initialization expression: " ++ show expr
 
 ppInitializeEnum ::

--- a/src/PPrinter/TypeDef/Definition.hs
+++ b/src/PPrinter/TypeDef/Definition.hs
@@ -1,0 +1,74 @@
+module PPrinter.TypeDef.Definition where
+
+import Prettyprinter
+
+import AST.Seman
+import PPrinter.Common
+import PPrinter.Statement
+import PPrinter.TypeDef.Declaration
+import Semantic.Monad (SemanticAnns)
+import Data.Map (empty)
+
+
+ppClassProcedureOnEntry :: DocStyle
+ppClassProcedureOnEntry = ppCFunctionCall resourceLock [pretty "self->__resource_id"] <> semi
+
+ppClassProcedureOnExit :: DocStyle
+ppClassProcedureOnExit = ppCFunctionCall resourceUnlock [pretty "self->__resource_id"] <> semi
+
+ppClassFunctionDefinition :: Identifier -> ClassMember SemanticAnns -> DocStyle
+ppClassFunctionDefinition classId (ClassProcedure identifier parameters blk _) =
+    -- | Function prototype
+    ppCFunctionPrototype (classFunctionName classId identifier)
+      (
+        -- | Print the self parameter
+        ppSelfParameter classId :
+        -- | Print the rest of the function parameters
+        (ppParameterDeclaration (classFunctionName classId identifier) <$> parameters)
+      )
+      -- | Class procedures do not return anything
+      Nothing
+    <+>
+    -- | Function body
+    braces' (line <>
+      (indentTab . align $
+        vsep (
+          -- | Print the resource lock call
+          [ppClassProcedureOnEntry, emptyDoc] ++
+          -- | Print the function body
+          [ppStatement subs s <> line | s <- blk] ++
+          -- | Print the resource unlock call
+          [ppClassProcedureOnExit, emptyDoc]
+        )
+        -- | Print the empty return statement
+        <> line <> returnC <> semi <> line)
+    ) <> line
+  where
+    subs = ppParameterSubstitutions parameters
+ppClassFunctionDefinition classId (ClassViewer identifier parameters rts body _) =
+    -- | Function prototype
+    ppCFunctionPrototype (classFunctionName classId identifier)
+      (
+        -- | Print the self parameter
+        pretty "const" <+> ppSelfParameter classId :
+        -- | Print the rest of the function parameters
+        (ppParameterDeclaration (classFunctionName classId identifier) <$> parameters)
+      )
+      -- | Class viewer return type
+      (Just (ppReturnType (pretty identifier) rts))
+    <+> ppBlockRet (ppParameterSubstitutions parameters) (classFunctionName classId identifier) body <> line
+ppClassFunctionDefinition classId (ClassMethod identifier mrts body _) =
+    -- | Function prototype
+    ppCFunctionPrototype (classFunctionName classId identifier)
+      -- | Print the self parameter
+      [ppSelfParameter classId]
+      -- | Class viewer return type
+      (ppReturnType (pretty identifier) <$> mrts)
+    <+> ppBlockRet empty (classFunctionName classId identifier) body <> line
+ppClassFunctionDefinition _ _ = error "invalid class member"
+
+ppClassDefinition :: TypeDef SemanticAnns -> DocStyle
+ppClassDefinition (Class _ identifier members _) =
+  let (_fields, methods, procedures, viewers) = classifyClassMembers members in
+    vsep $ map (ppClassFunctionDefinition identifier) (methods ++ procedures ++ viewers)
+ppClassDefinition _ = error "AST element is not a class"

--- a/src/Parser/Parsing.hs
+++ b/src/Parser/Parsing.hs
@@ -240,11 +240,13 @@ fieldAssignmentsExpressionParser = do
       flAddresses = do
             identifier <- identifierParser
             _ <- reservedOp "@"
-            FieldAddressAssignment identifier <$> hexa
+            p' <- getPosition
+            flip (FieldAddressAssignment identifier) (Position p') <$> hexa
       flConnection = do
             identifier <- identifierParser
             _ <- reservedOp "<-"
-            FieldPortConnection identifier <$> identifierParser
+            p' <- getPosition
+            flip (FieldPortConnection identifier) (Position p') <$> identifierParser
 
 -- | Parser for an element modifier
 -- A modifier is of the form:

--- a/src/Semantic/TypeChecking.hs
+++ b/src/Semantic/TypeChecking.hs
@@ -493,18 +493,18 @@ checkFieldValue loc objType (FieldDefinition fid fty) (FieldValueAssignment faid
   then
     SAST.FieldValueAssignment faid <$> (expressionType objType faexp >>= mustBeTy fty)
   else throwError $ annotateError loc (EFieldMissing [fid])
-checkFieldValue loc _ (FieldDefinition fid fty) (FieldAddressAssignment faid addr) =
+checkFieldValue loc _ (FieldDefinition fid fty) (FieldAddressAssignment faid addr pann) =
   if fid == faid
   then
     case fty of
-      Location _ -> return $ SAST.FieldAddressAssignment faid addr
+      Location _ -> return $ SAST.FieldAddressAssignment faid addr (buildExpAnn pann fty)
       _ -> throwError $ annotateError loc (EFieldNotFixedLocation fid)
   else throwError $ annotateError loc (EFieldMissing [fid])
-checkFieldValue loc _ (FieldDefinition fid fty) (FieldPortConnection pid sid) =
+checkFieldValue loc _ (FieldDefinition fid fty) (FieldPortConnection pid sid pann) =
   if fid == pid
   then
     case fty of
-      Port _ -> return $ SAST.FieldPortConnection pid sid
+      Port _ -> return $ SAST.FieldPortConnection pid sid (buildExpAnn pann fty)
       _ -> throwError $ annotateError loc (EFieldNotPort fid)
   else throwError $ annotateError loc (EFieldMissing [fid])
 
@@ -519,8 +519,8 @@ checkFieldValues loc objType fds fas = checkSortedFields sorted_fds sorted_fas [
     tError = throwError . annotateError loc
     getFid = \case {
       FieldValueAssignment fid _ -> fid;
-      FieldAddressAssignment fid _ -> fid;
-      FieldPortConnection fid _ -> fid;
+      FieldAddressAssignment fid _ _ -> fid;
+      FieldPortConnection fid _ _ -> fid;
     }
     sorted_fds = Data.List.sortOn fieldIdentifier fds
     sorted_fas = Data.List.sortOn getFid fas


### PR DESCRIPTION
First version of the global object initialization function generator. This function is independent of the underlying operating system. The function is responsible for initializing the state of the various global objects. This function must be called by the runtime ONLY ONCE before the different tasks are launched and the interrupt handlers can be executed.

In order to properly implement this function, it has been necessary to modify the AST to add type annotations in the assignment of `Location` and `Port` type fields.

A small code restructuring has also been performed. Future reorganization and refactoring of the printing functions, which are now split between the `PPrinter` directory and the `Modules` directory, will be necessary.