### PR TITLE
Added support for non-dynamic Options

### DIFF
--- a/src/AST/Core.hs
+++ b/src/AST/Core.hs
@@ -110,13 +110,13 @@ data TypeSpecifier
   | Port TypeSpecifier
   -- See Q9
   | Unit
-  deriving (Show)
+  deriving (Show, Ord, Eq)
 
 data AccessKind = Immutable | Mutable | Private
-  deriving (Show)
+  deriving (Show, Ord, Eq)
 
 newtype Size = K Integer
- deriving (Show)
+ deriving (Show, Ord, Eq)
 
 data Op
   = Multiplication

--- a/src/PPrinter.hs
+++ b/src/PPrinter.hs
@@ -11,6 +11,7 @@ import Prettyprinter
 import Prettyprinter.Render.Terminal
 
 import Data.Text (Text, pack, intercalate, replace, toUpper)
+import Semantic.Option (OptionMap)
 
 import PPrinter.Common
 import PPrinter.TypeDef.Declaration
@@ -26,13 +27,13 @@ render = renderStrict . layoutSmart defaultLayoutOptions
 ppEmptyDoc :: a -> Doc ann
 ppEmptyDoc = const emptyDoc
 
-ppHeaderASTElement :: AnnASTElement SemanticAnns -> Maybe DocStyle
-ppHeaderASTElement (TypeDefinition t _) = Just (ppTypeDefDeclaration t)
-ppHeaderASTElement (GlobalDeclaration obj@(Resource {})) = Just (ppGlobalDeclaration obj)
-ppHeaderASTElement (GlobalDeclaration obj@(Task {})) = Just (ppGlobalDeclaration obj)
-ppHeaderASTElement (GlobalDeclaration obj@(Handler {})) = Just (ppGlobalDeclaration obj)
-ppHeaderASTElement func@(Function {}) = Just (ppFunctionDeclaration func)
-ppHeaderASTElement _ = Nothing
+ppHeaderASTElement :: OptionMap -> AnnASTElement SemanticAnns -> Maybe DocStyle
+ppHeaderASTElement opts (TypeDefinition t _) = Just (ppTypeDefDeclaration opts t)
+ppHeaderASTElement _ (GlobalDeclaration obj@(Resource {})) = Just (ppGlobalDeclaration obj)
+ppHeaderASTElement _ (GlobalDeclaration obj@(Task {})) = Just (ppGlobalDeclaration obj)
+ppHeaderASTElement _ (GlobalDeclaration obj@(Handler {})) = Just (ppGlobalDeclaration obj)
+ppHeaderASTElement _ func@(Function {}) = Just (ppFunctionDeclaration func)
+ppHeaderASTElement _ _ = Nothing
 
 ppSourceASTElement :: AnnASTElement SemanticAnns -> Maybe DocStyle
 ppSourceASTElement (TypeDefinition (Struct {}) _) = Nothing

--- a/src/PPrinter/Application/Option.hs
+++ b/src/PPrinter/Application/Option.hs
@@ -1,0 +1,30 @@
+module PPrinter.Application.Option where
+
+import PPrinter.Common
+import AST.Seman
+import Prettyprinter
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Semantic.Option (OptionMap)
+
+ppSimpleOptionDefinition :: TypeSpecifier -> DocStyle
+ppSimpleOptionDefinition (Option ts) = vsep [
+        ppOptionSomeParameterStruct ts,
+        emptyDoc,
+        ppOptionStruct ts,
+        emptyDoc
+    ]
+ppSimpleOptionDefinition ts = error $ "invalid non-primitive type specifier: " ++ show ts
+
+ppSimpleOptionTypesFile :: OptionMap -> DocStyle
+ppSimpleOptionTypesFile opts =
+    vsep $ [
+        pretty "#ifndef __OPTION_H__",
+        pretty "#define __OPTION_H__",
+        emptyDoc,
+        pretty "#include <termina.h>"
+    ] ++
+    concat ((map (\s -> emptyDoc : (map ppSimpleOptionDefinition (S.toList s))) $ M.elems opts)) ++
+    [
+        pretty "#endif // __OPTION_H__"
+    ]

--- a/src/Parser/Parsing.hs
+++ b/src/Parser/Parsing.hs
@@ -50,8 +50,8 @@ lexer = Tok.makeTokenParser langDef
       ,"usize", "bool","char"]
       ++ -- Polymorphic Types
       ["MsgQueue", "Pool", "Option"]
-      ++ -- Struct and Union Types
-      ["struct","union"]
+      ++ -- Struct and enum types
+      ["struct", "enum"]
       ++ -- Dynamic Subtyping
       ["dyn"]
       ++ -- Fixed Location Subtyping
@@ -72,6 +72,10 @@ lexer = Tok.makeTokenParser langDef
       ["import"]
       ++ -- Class methods
       ["procedure", "viewer", "method"]
+      ++ -- Casting keyword
+      ["as"]
+      ++ -- option name
+      ["option"]
 
     langDef =
       Lang.emptyDef{ Tok.commentStart = "/*"
@@ -898,7 +902,7 @@ moduleInclusionParser :: Parser [ Module ]
 moduleInclusionParser = do
   reserved "import"
   modules <- braces (sepBy1 (wspcs *> singleModule <* wspcs) comma)
-  return $ map (\(mod, ident, ann) -> ModInclusion ident mod) modules
+  return $ map (\(mod, ident, _ann) -> ModInclusion ident mod) modules
 
 contents :: Parser a -> Parser a
 contents p = wspcs *> p <* eof

--- a/src/Semantic/Errors/Errors.hs
+++ b/src/Semantic/Errors/Errors.hs
@@ -133,6 +133,8 @@ data Errors a
   | EInvalidClassFieldType TypeSpecifier
   -- | Forbidden Reference Type
   | EReferenceTy TypeSpecifier
+  -- | Nested Option
+  | EOptionNested 
   -- | Complex expression on LHS
   | ELHSComplex
   -- | Struct Definition
@@ -186,7 +188,7 @@ data Errors a
   | EMsgQueueWrongProcedure Identifier
   | ENoMsgQueueSendWrongArgs
   | ENoMsgQueueRcvWrongArgs
-  | EMsgQueueSendArgNotDyn TypeSpecifier
+  | EMsgQueueSendArgNotObject
   | EMsgQueueSendArgNotRefMutResult TypeSpecifier
   | EMsgQueueSendArgNotRefImmTimeout TypeSpecifier
   | EMsgQueueWrongType TypeSpecifier TypeSpecifier

--- a/src/Semantic/Option.hs
+++ b/src/Semantic/Option.hs
@@ -1,0 +1,132 @@
+module Semantic.Option where
+
+-- Termina Semantic AST
+import AST.Seman as SAST
+import Utils.TypeSpecifier
+
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Control.Monad
+
+type OptionMap = M.Map TypeSpecifier (S.Set TypeSpecifier)
+
+insertOptionType :: Monad m
+  -- | The initial map with the all the option types
+  => OptionMap
+  -- | The new element
+  -> TypeSpecifier
+  -- | The resulting map
+  -> m OptionMap
+insertOptionType prevMap (Vector ts _) = insertOptionType prevMap ts
+insertOptionType prevMap ts =
+  if isNonDynOption ts then
+    maybe
+      -- | if the root type is not in the map, insert it
+      (return $ M.insert (rootType ts) (S.singleton ts) prevMap)
+      -- | if the root type is in the map, insert the new option type in the set 
+      (\ps -> return $ M.insert (rootType ts) (S.insert ts ps) prevMap) $ M.lookup (rootType ts) prevMap
+  else return prevMap
+
+mapParameterOption :: Monad m
+  -- | The initial map with the all the option types
+  => OptionMap
+  -- | The new parameter
+  -> Parameter
+  -- | The resulting map
+  -> m OptionMap
+mapParameterOption prevMap (Parameter _ ts) = insertOptionType prevMap ts
+
+mapMaybeOption :: Monad m
+  -- | The initial map with the all the option types
+  => OptionMap
+  -- | The new element
+  -> Maybe TypeSpecifier
+  -- | The resulting map
+  -> m OptionMap
+mapMaybeOption prevMap (Just ts) = insertOptionType prevMap ts
+mapMaybeOption prevMap Nothing = return prevMap
+
+mapStatementOption :: Monad m
+  -- | The initial map with the all the option types
+  => OptionMap
+  -- | The new element
+  -> Statement a
+  -- | The resulting map
+  -> m OptionMap
+mapStatementOption prevMap (Declaration _ _ ts _ _) = insertOptionType prevMap ts
+mapStatementOption prevMap (IfElseStmt _ stmts elseIfs esleStmts _) =
+  -- | Get the option types from the statements
+  foldM mapStatementOption prevMap stmts >>=
+  -- | Get the option types from the else if statements
+  flip (foldM (\m (ElseIf _ stmts' _) -> foldM mapStatementOption m stmts')) elseIfs >>=
+  -- | Get the option types from the else statements
+  flip (foldM mapStatementOption) esleStmts
+mapStatementOption prevMap (ForLoopStmt _ _ _ _ _ stmts _) = foldM mapStatementOption prevMap stmts
+mapStatementOption prevMap (MatchStmt _ cases _) =
+  foldM (\m (MatchCase _ _ stmts _) -> foldM mapStatementOption m stmts) prevMap cases
+mapStatementOption prevMap _ = return prevMap
+
+mapClassMemberOption :: Monad m
+  -- | The initial map with the all the option types
+  => OptionMap
+  -- | The new element
+  -> ClassMember a
+  -- | The resulting map
+  -> m OptionMap
+mapClassMemberOption prevMap (ClassField field _) = insertOptionType prevMap (fieldTypeSpecifier field)
+mapClassMemberOption prevMap (ClassMethod _ maybeRet blkRet _) =
+  -- | Get the option types from the return type
+  mapMaybeOption prevMap maybeRet >>=
+  -- | Get the option types from the block return type
+  flip (foldM mapStatementOption) (blockBody blkRet)
+mapClassMemberOption prevMap (ClassProcedure _ params blk _) =
+  -- | Get the option types from the parameters
+  foldM mapParameterOption prevMap params >>=
+  -- | Get the option types from the block return type
+  flip (foldM mapStatementOption) blk
+mapClassMemberOption prevMap (ClassViewer _ params ret blkRet _) =
+  -- | Get the option types from the parameters
+  foldM mapParameterOption prevMap params >>=
+  -- | Get the option types from the return type
+  flip insertOptionType ret >>=
+  -- | Get the option types from the block return type
+  flip (foldM mapStatementOption) (blockBody blkRet)
+
+mapTypeDefOption :: Monad m
+  -- | The initial map with the all the option types
+  => OptionMap
+  -- | The new element
+  -> TypeDef a
+  -- | The resulting map
+  -> m OptionMap
+mapTypeDefOption prevMap (Struct _ fields _) =
+  -- | Get the option types from the fields
+  foldM (\m (FieldDefinition _ ts) -> insertOptionType m ts) prevMap fields
+mapTypeDefOption prevMap (Enum _ variants _) =
+  -- | Get the option types from the fields
+  foldM (\m (EnumVariant _ tss) -> foldM insertOptionType m tss) prevMap variants
+mapTypeDefOption prevMap (Class _ _ members _) =
+  -- | Get the option types from the class members
+  foldM mapClassMemberOption prevMap members
+
+mapOptions :: Monad m
+  -- | The initial map with the all the option types
+  => OptionMap
+  -- | The new element
+  -> AnnASTElement a
+  -- | The resulting map
+  -> m OptionMap
+mapOptions prevMap (Function _ params maybeRet blkRet _ _) =
+  -- | Get the option types from the parameters
+  foldM mapParameterOption prevMap params >>=
+  -- | Get the option types from the return type (it may return a regular Option)
+  flip mapMaybeOption maybeRet >>=
+  -- | Get the option types from the return block
+  flip (foldM mapStatementOption) (blockBody blkRet)
+mapOptions prevMap (TypeDefinition typeDef _) =
+  -- | Get the option types from the type definition
+  mapTypeDefOption prevMap typeDef
+mapOptions prevMap (GlobalDeclaration (Resource _ (MsgQueue ts _) _ _ _)) = 
+  -- | Get the option types from the message queue type
+  insertOptionType prevMap (Option ts)
+mapOptions prevMap _ = return prevMap

--- a/src/Utils/TypeSpecifier.hs
+++ b/src/Utils/TypeSpecifier.hs
@@ -27,6 +27,7 @@ primitiveTypes  _              = False
 -- Definition https://hackmd.io/a4CZIjogTi6dXy3RZtyhCA?view#Simple-types
 simpleType :: TypeSpecifier -> Bool
 simpleType Unit                = False
+simpleType (Option (DynamicSubtype {})) = False
 simpleType (DynamicSubtype {}) = False
 simpleType (MsgQueue {})       = False
 simpleType (Pool {})           = False
@@ -36,12 +37,13 @@ simpleType (Port {})           = False
 simpleType _                   = True
 
 classFieldType :: TypeSpecifier -> Bool
-classFieldType Unit                = False
-classFieldType (DynamicSubtype {}) = False
-classFieldType (MsgQueue {})       = False
-classFieldType (Pool {})           = False
-classFieldType (Reference {})      = False
-classFieldType _                   = True
+classFieldType Unit                         = False
+classFieldType (DynamicSubtype {})          = False
+classFieldType (Option (DynamicSubtype {})) = False
+classFieldType (MsgQueue {})                = False
+classFieldType (Pool {})                    = False
+classFieldType (Reference {})               = False
+classFieldType _                            = True
 
 boolTy :: TypeSpecifier -> Bool
 boolTy Bool = True
@@ -90,9 +92,29 @@ identifierType (Class _ ident _ _)  = ident
 
 referenceType :: TypeSpecifier -> Bool
 referenceType Unit           = False
+referenceType (MsgQueue {})  = False
+referenceType (Pool {})      = False
 referenceType (Reference {}) = False
+referenceType (Location {})  = False
+referenceType (Port {})      = False
 referenceType _              = True
 
 isDyn :: TypeSpecifier -> Maybe TypeSpecifier
 isDyn (DynamicSubtype t) = Just t
 isDyn _ = Nothing
+
+isNonDynOption :: TypeSpecifier -> Bool
+isNonDynOption (Option (DynamicSubtype _)) = False
+isNonDynOption (Option _) = True
+isNonDynOption _ = False
+
+rootType :: TypeSpecifier -> TypeSpecifier
+rootType (Option ts) = rootType ts
+rootType (Vector ts _) = rootType ts
+rootType (MsgQueue ts _) = rootType ts
+rootType (Pool ts _) = rootType ts
+rootType (Reference _ ts) = rootType ts
+rootType (DynamicSubtype ts) = rootType ts
+rootType (Location ts) = rootType ts
+rootType (Port ts) = rootType ts
+rootType t = t

--- a/test/IT/Expression/ArithmeticSpec.hs
+++ b/test/IT/Expression/ArithmeticSpec.hs
@@ -7,6 +7,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function test0() {\n" ++
@@ -45,7 +46,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Expression/BitwiseSpec.hs
+++ b/test/IT/Expression/BitwiseSpec.hs
@@ -7,6 +7,7 @@ import Text.Parsec
 import Semantic.TypeChecking
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function bitwise_test0(foo : u16) {\n" ++
@@ -30,7 +31,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Expression/CastSpec.hs
+++ b/test/IT/Expression/CastSpec.hs
@@ -7,6 +7,7 @@ import Text.Parsec
 import Semantic.TypeChecking
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function casting_test0() {\n" ++
@@ -30,7 +31,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Expression/FunctionCallSpec.hs
+++ b/test/IT/Expression/FunctionCallSpec.hs
@@ -7,6 +7,7 @@ import Text.Parsec
 import Semantic.TypeChecking
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function func_test0_0(a : u16) -> u16 {\n" ++
@@ -37,7 +38,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Expression/RelationalSpec.hs
+++ b/test/IT/Expression/RelationalSpec.hs
@@ -7,6 +7,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function relational_test0(foo : u16) {\n" ++
@@ -33,7 +34,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Expression/VectorIndexSpec.hs
+++ b/test/IT/Expression/VectorIndexSpec.hs
@@ -7,6 +7,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function vector_test0() {\n" ++
@@ -33,7 +34,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Expression/VectorSliceSpec.hs
+++ b/test/IT/Expression/VectorSliceSpec.hs
@@ -7,6 +7,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function slice_test0() {\n" ++
@@ -53,7 +54,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Global/PoolSpec.hs
+++ b/test/IT/Global/PoolSpec.hs
@@ -7,6 +7,7 @@ import Text.Parsec
 import Semantic.TypeChecking
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "enum Message {\n" ++
@@ -24,7 +25,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 spec :: Spec
 spec = do

--- a/test/IT/Statement/AssignmentSpec.hs
+++ b/test/IT/Statement/AssignmentSpec.hs
@@ -7,6 +7,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function assignment_test0() {\n" ++
@@ -18,8 +19,8 @@ test0 = "function assignment_test0() {\n" ++
 
 test1 :: String
 test1 = "function assignment_test1(dyn_var0 : dyn u32) {\n" ++
-        "    var option : Option<dyn u32> = None;\n" ++
-        "    option = Some(dyn_var0);\n" ++
+        "    var opt : Option<dyn u32> = None;\n" ++
+        "    opt = Some(dyn_var0);\n" ++
         "    return;\n" ++
         "}"
 
@@ -47,7 +48,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of
@@ -103,12 +104,12 @@ spec = do
               "\n" ++ 
               "void assignment_test1(__termina_dyn_t dyn_var0) {\n" ++
               "\n" ++
-              "    __termina_option_dyn_t option;\n" ++
+              "    __option_dyn_t opt;\n" ++
               "\n" ++
-              "    option.__variant = None;\n" ++
+              "    opt.__variant = None;\n" ++
               "\n" ++
-              "    option.__variant = Some;\n" ++
-              "    option.Some.__0 = dyn_var0;\n" ++
+              "    opt.__variant = Some;\n" ++
+              "    opt.Some.__0 = dyn_var0;\n" ++
               "\n" ++
               "    return;\n" ++
               "\n" ++

--- a/test/IT/Statement/ForLoopSpec.hs
+++ b/test/IT/Statement/ForLoopSpec.hs
@@ -7,6 +7,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function for_loop_test0(array0 : [u16; 10]) -> u16 {\n" ++
@@ -34,7 +35,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/Statement/MatchSpec.hs
+++ b/test/IT/Statement/MatchSpec.hs
@@ -7,6 +7,7 @@ import Semantic.TypeChecking
 import Text.Parsec
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "function match_test0(option0 : Option<dyn u32>) -> u32 {\n" ++
@@ -69,7 +70,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of
@@ -89,7 +90,7 @@ spec = do
               "\n" ++
               "#include <termina.h>\n" ++
               "\n" ++
-              "uint32_t match_test0(__termina_option_dyn_t option0);\n" ++
+              "uint32_t match_test0(__option_dyn_t option0);\n" ++
               "\n" ++
               "#endif // __TEST_H__\n")
     it "Prints definition of function match_test0" $ do
@@ -97,7 +98,7 @@ spec = do
         pack ("\n" ++
               "#include \"test.h\"\n" ++
               "\n" ++ 
-              "uint32_t match_test0(__termina_option_dyn_t option0) {\n" ++
+              "uint32_t match_test0(__option_dyn_t option0) {\n" ++
               "\n" ++
               "    uint32_t ret = 0;\n" ++
               "\n" ++
@@ -107,7 +108,7 @@ spec = do
               "\n" ++
               "    } else {\n" ++
               "\n" ++
-              "        __termina_option_dyn_t __option0__Some = option0.Some.__0;\n" ++
+              "        __option_dyn_t __option0__Some = option0.Some.__0;\n" ++
               "\n" ++
               "        ret = *((uint32_t *)__option0__Some.data);\n" ++
               "\n" ++
@@ -123,7 +124,7 @@ spec = do
               "\n" ++
               "#include <termina.h>\n" ++
               "\n" ++
-              "uint32_t match_test1(__termina_option_dyn_t option0);\n" ++
+              "uint32_t match_test1(__option_dyn_t option0);\n" ++
               "\n" ++
               "#endif // __TEST_H__\n")
     it "Prints definition of function match_test1" $ do
@@ -131,7 +132,7 @@ spec = do
         pack ("\n" ++
               "#include \"test.h\"\n" ++
               "\n" ++ 
-              "uint32_t match_test1(__termina_option_dyn_t option0) {\n" ++
+              "uint32_t match_test1(__option_dyn_t option0) {\n" ++
               "\n" ++
               "    uint32_t ret = 0;\n" ++
               "\n" ++
@@ -140,7 +141,7 @@ spec = do
               "        \n" ++
               "    } else {\n" ++
               "\n" ++
-              "        __termina_option_dyn_t __option0__Some = option0.Some.__0;\n" ++
+              "        __option_dyn_t __option0__Some = option0.Some.__0;\n" ++
               "\n" ++
               "        ret = *((uint32_t *)__option0__Some.data);\n" ++
               "\n" ++

--- a/test/IT/TypeDef/ResourceSpec.hs
+++ b/test/IT/TypeDef/ResourceSpec.hs
@@ -7,6 +7,7 @@ import Text.Parsec
 import Semantic.TypeChecking
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
 
 test0 :: String
 test0 = "resource class TMChannel {\n" ++
@@ -36,7 +37,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile False M.empty (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of

--- a/test/IT/TypeDef/TaskSpec.hs
+++ b/test/IT/TypeDef/TaskSpec.hs
@@ -5,13 +5,16 @@ import Parser.Parsing
 import Data.Text hiding (empty)
 import Text.Parsec
 import Semantic.TypeChecking
+import qualified AST.Seman as SAST
 import Prettyprinter
 import Modules.Printing
+import qualified Data.Map as M
+import qualified Data.Set as S
 
 test0 :: String
 test0 = "struct Message {\n" ++
         "    sender_id : u32;\n" ++
-        "    destination_id : u32;\n" ++
+        "    destination_id : Option<u32>;\n" ++
         "    urgent : bool;\n" ++
         "};\n" ++
         "\n" ++
@@ -61,7 +64,7 @@ renderHeader input = case parse (contents topLevel) "" input of
   Right ast -> 
     case typeCheckRun ast of
       Left err -> pack $ "Type error: " ++ show err
-      Right tast -> ppHeaderFile (pretty "__TEST_H__") emptyDoc tast
+      Right tast -> ppHeaderFile True (M.fromList [(SAST.UInt32, S.fromList [(SAST.Option SAST.UInt32)])]) (pretty "__TEST_H__") emptyDoc tast
 
 renderSource :: String -> Text
 renderSource input = case parse (contents topLevel) "" input of
@@ -81,9 +84,11 @@ spec = do
               "\n" ++
               "#include <termina.h>\n" ++
               "\n" ++
+              "#include \"option.h\"\n" ++
+              "\n" ++
               "typedef struct {\n" ++
               "    uint32_t sender_id;\n" ++
-              "    uint32_t destination_id;\n" ++
+              "    __option_uint32_t destination_id;\n" ++
               "    _Bool urgent;\n" ++
               "} Message;\n" ++
               "\n" ++   
@@ -112,7 +117,7 @@ spec = do
               "\n" ++
               "    self->interval = self->interval + 1;\n" ++
               "\n" ++
-              "    __termina_option_dyn_t alloc_msg;\n" ++
+              "    __option_dyn_t alloc_msg;\n" ++
               "\n" ++
               "    alloc_msg.__variant = None;\n" ++
               "\n" ++   
@@ -123,7 +128,7 @@ spec = do
               "        \n"  ++           
               "    } else {\n" ++
               "\n" ++   
-              "        __termina_option_dyn_t __alloc_msg__Some = alloc_msg.Some.__0;\n" ++
+              "        __option_dyn_t __alloc_msg__Some = alloc_msg.Some.__0;\n" ++
               "\n" ++
               "        *((Message *)__alloc_msg__Some.data).urgent = 0;\n" ++
               "\n" ++

--- a/test/UT/PPrinter/Expression/MemberFunctionAccessSpec.hs
+++ b/test/UT/PPrinter/Expression/MemberFunctionAccessSpec.hs
@@ -9,8 +9,9 @@ import PPrinter.Expression
 import UT.PPrinter.Expression.Common
 import Semantic.Monad
 
-self, tmChannel, tmPool, bar0, bar1 :: Object SemanticAnns
+self, result, tmChannel, tmPool, bar0, bar1 :: Object SemanticAnns
 self = Variable "self" (refDefinedTypeSemAnn "Resource")
+result = Variable "result" (definedTypeSemAnn Mutable "Result")
 tmChannel = Variable "tm_channel" (msgQueueSemAnn (DefinedType "TMDescriptor") 10)
 tmPool = Variable "tm_pool" (poolSemAnn UInt32 10)
 bar0 = Variable "bar0" (objSemAnn Mutable UInt16)
@@ -22,8 +23,11 @@ tmPoolAlloc = MemberFunctionAccess tmPool "alloc" [] unitSemAnn
 selfDereference :: Object SemanticAnns
 selfDereference = Dereference self (definedTypeSemAnn Private "Resource")
 
+resultReference :: Expression SemanticAnns
+resultReference = ReferenceExpression Mutable result (definedTypeSemAnn Private "Result")
+
 tmChannelsend, selfFoo0 :: Expression SemanticAnns
-tmChannelsend = MemberFunctionAccess tmChannel "send" [AccessObject bar0] unitSemAnn
+tmChannelsend = MemberFunctionAccess tmChannel "send" [AccessObject bar0, resultReference] unitSemAnn
 selfFoo0 = MemberFunctionAccess selfDereference "foo0" [AccessObject bar0, AccessObject bar1] unitSemAnn
 
 renderExpression :: Expression SemanticAnns -> Text
@@ -37,7 +41,7 @@ spec = do
         pack "__termina__pool_alloc(tm_pool)"
     it "Prints the expression: tm_channel.foo0(bar0)" $ do
       renderExpression tmChannelsend `shouldBe`
-        pack "__termina__msg_queue_send(tm_channel, bar0)"
+        pack "__termina__msg_queue_send(tm_channel, (void *)&bar0, &result)"
     it "Prints the expression: (*self).foo0(bar0, bar1)" $ do
       renderExpression selfFoo0 `shouldBe`
         pack "Resource__foo0(self, bar0, bar1)"

--- a/test/UT/PPrinter/Statement/IfElseSpec.hs
+++ b/test/UT/PPrinter/Statement/IfElseSpec.hs
@@ -86,7 +86,7 @@ spec = do
           "        vector1[__i0] = vector0[__i0];\n" ++
           "    }\n" ++
           "\n" ++
-          "    __termina_option_dyn_t option0;\n" ++
+          "    __option_dyn_t option0;\n" ++
           "\n" ++
           "    option0.__variant = Some;\n" ++
           "    option0.Some.__0 = dyn_var0;\n" ++
@@ -103,14 +103,14 @@ spec = do
           "        vector1[__i0] = vector0[__i0];\n" ++
           "    }\n" ++
           "\n" ++
-          "    __termina_option_dyn_t option0;\n" ++
+          "    __option_dyn_t option0;\n" ++
           "\n" ++
           "    option0.__variant = Some;\n" ++
           "    option0.Some.__0 = dyn_var0;\n" ++
           "\n" ++
           "} else {\n" ++
           "\n" ++
-          "    __termina_option_dyn_t option1;\n" ++
+          "    __option_dyn_t option1;\n" ++
           "\n" ++
           "    option1.__variant = None;\n" ++
           "\n" ++
@@ -126,7 +126,7 @@ spec = do
           "        vector1[__i0] = vector0[__i0];\n" ++
           "    }\n" ++
           "\n" ++
-          "    __termina_option_dyn_t option0;\n" ++
+          "    __option_dyn_t option0;\n" ++
           "\n" ++
           "    option0.__variant = Some;\n" ++
           "    option0.Some.__0 = dyn_var0;\n" ++
@@ -137,7 +137,7 @@ spec = do
           "\n" ++
           "} else {\n" ++
           "\n" ++
-          "    __termina_option_dyn_t option1;\n" ++
+          "    __option_dyn_t option1;\n" ++
           "\n" ++
           "    option1.__variant = None;\n" ++
           "\n" ++

--- a/test/UT/PPrinter/Statement/MatchSpec.hs
+++ b/test/UT/PPrinter/Statement/MatchSpec.hs
@@ -83,7 +83,7 @@ spec = do
         pack (
           "if (option_var.__variant == Some) {\n" ++
           "\n" ++
-          "    __termina_option_dyn_t __option_var__Some = option_var.Some.__0;\n" ++
+          "    __option_dyn_t __option_var__Some = option_var.Some.__0;\n" ++
           "\n" ++
           "    foo1 = *((uint32_t *)__option_var__Some.data);\n" ++
           "\n" ++
@@ -101,7 +101,7 @@ spec = do
           "\n" ++
           "} else {\n" ++
           "\n" ++
-          "    __termina_option_dyn_t __option_var__Some = option_var.Some.__0;\n" ++
+          "    __option_dyn_t __option_var__Some = option_var.Some.__0;\n" ++
           "\n" ++
           "    foo1 = ((uint32_t *)__option_var__Some.data)[8];\n" ++
           "\n" ++
@@ -110,7 +110,7 @@ spec = do
       renderStatement matchOption2 `shouldBe`
         pack (
           "{\n" ++
-          "    __termina_option_dyn_t __match = get_integer();\n" ++
+          "    __option_dyn_t __match = get_integer();\n" ++
           "\n" ++
           "    if (__match.__variant == Some) {\n" ++
           "\n" ++

--- a/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
+++ b/test/UT/PPrinter/Statement/VariableInitializationSpec.hs
@@ -103,14 +103,14 @@ spec = do
     it "Prints the statement var option0 : Option <'dyn u32> = Some(dyn_var0);" $ do
       renderStatement option0 `shouldBe`
         pack (
-          "__termina_option_dyn_t option0;\n" ++
+          "__option_dyn_t option0;\n" ++
           "\n" ++
           "option0.__variant = Some;\n" ++
           "option0.Some.__0 = dyn_var0;")
     it "Prints the statement var option1 : Option <'dyn u32> = None;" $ do
       renderStatement option1 `shouldBe`
         pack (
-          "__termina_option_dyn_t option1;\n" ++
+          "__option_dyn_t option1;\n" ++
           "\n" ++
           "option1.__variant = None;")
   describe "Pretty printing enum variable declarations" $ do

--- a/test/UT/PPrinter/TypeDef/ClassSpec.hs
+++ b/test/UT/PPrinter/TypeDef/ClassSpec.hs
@@ -5,7 +5,9 @@ import PPrinter
 import AST.Seman
 import Data.Text
 import Semantic.Monad
+import Semantic.Option (OptionMap)
 import Data.Maybe
+import qualified Data.Map as M
 
 
 classWithOneProcedureAndZeroFields :: AnnASTElement SemanticAnns
@@ -96,14 +98,14 @@ classWithFixedLocationField = TypeDefinition
     ClassProcedure "procedure0" [] [] undefined
   ] []) undefined
 
-renderTypedefDeclaration :: AnnASTElement SemanticAnns -> Text
-renderTypedefDeclaration = render . fromJust . ppHeaderASTElement
+renderTypedefDeclaration :: OptionMap -> AnnASTElement SemanticAnns -> Text
+renderTypedefDeclaration opts = render . fromJust . (ppHeaderASTElement opts)
 
 spec :: Spec
 spec = do
   describe "Pretty printing classes" $ do
     it "Prints a class with one procedure and zero fields" $ do
-      renderTypedefDeclaration classWithOneProcedureAndZeroFields `shouldBe`
+      renderTypedefDeclaration M.empty classWithOneProcedureAndZeroFields `shouldBe`
         pack (
           "typedef struct {\n" ++
           "    __termina_resource_t __resource_id;\n" ++
@@ -113,18 +115,17 @@ spec = do
           "                     uint32_t param2, uint64_t param3, int8_t param4,\n" ++
           "                     int16_t param5, int32_t param6, int64_t param7);\n")
     it "Prints a class with two procedures and zero fields" $ do
-      renderTypedefDeclaration classWithTwoProceduresAndZeroFields `shouldBe`
+      renderTypedefDeclaration M.empty classWithTwoProceduresAndZeroFields `shouldBe`
         pack (
           "typedef struct {\n" ++
           "    __termina_resource_t __resource_id;\n" ++
           "} id0;\n" ++
           "\n" ++
-          "void id0__procedure0(id0 * const self, uint8_t param0,\n" ++
-          "                     __termina_option_dyn_t param1);\n" ++
+          "void id0__procedure0(id0 * const self, uint8_t param0, __option_dyn_t param1);\n" ++
           "\n" ++
           "void id0__procedure1(id0 * const self, uint8_t param0, uint8_t param1[32]);\n")
     it "Prints a class marked as no_handler with one procedure and zero fields" $ do
-      renderTypedefDeclaration noHandlerClassWithoutOneProcedureAndZeroFields `shouldBe`
+      renderTypedefDeclaration M.empty noHandlerClassWithoutOneProcedureAndZeroFields `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    __termina_resource_t __resource_id;\n" ++
@@ -132,7 +133,7 @@ spec = do
             "\n" ++
             "void id0__procedure0(id0 * const self);\n")
     it "Prints a class marked as no_handler with two fields" $ do
-      renderTypedefDeclaration noHandlerClassWithOneEmptyProcedure `shouldBe`
+      renderTypedefDeclaration M.empty noHandlerClassWithOneEmptyProcedure `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
@@ -142,7 +143,7 @@ spec = do
             "\n" ++
             "void id0__procedure0(id0 * const self);\n")
     it "Prints a class with one procedure and two fields" $ do
-      renderTypedefDeclaration classWithOneProcedureAndTwoFields `shouldBe`
+      renderTypedefDeclaration M.empty classWithOneProcedureAndTwoFields `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
@@ -152,7 +153,7 @@ spec = do
             "\n" ++
             "void id0__procedure0(id0 * const self);\n")
     it "Prints a packed class" $ do
-      renderTypedefDeclaration packedClass `shouldBe`
+      renderTypedefDeclaration M.empty packedClass `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint64_t field0;\n" ++
@@ -163,7 +164,7 @@ spec = do
             "\n" ++
             "void id0__procedure0(id0 * const self, char param0, uint8_t param1[16]);\n")
     it "Prints an aligned class" $ do
-      renderTypedefDeclaration alignedClass `shouldBe`
+      renderTypedefDeclaration M.empty alignedClass `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint64_t field0;\n" ++
@@ -174,7 +175,7 @@ spec = do
             "\n" ++
             "void id0__procedure0(id0 * const self);\n")
     it "Prints a packed & aligned class" $ do
-      renderTypedefDeclaration packedAndAlignedClass `shouldBe`
+      renderTypedefDeclaration M.empty packedAndAlignedClass `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint64_t field0;\n" ++
@@ -185,7 +186,7 @@ spec = do
             "\n" ++
             "void id0__procedure0(id0 * const self);\n")
     it "Prints a class with a fixed location field" $ do
-      renderTypedefDeclaration classWithFixedLocationField `shouldBe`
+      renderTypedefDeclaration M.empty classWithFixedLocationField `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint32_t field0;\n" ++

--- a/test/UT/PPrinter/TypeDef/EnumSpec.hs
+++ b/test/UT/PPrinter/TypeDef/EnumSpec.hs
@@ -5,7 +5,9 @@ import PPrinter
 import AST.Seman
 import Data.Text
 import Semantic.Monad
+import Semantic.Option (OptionMap)
 import Data.Maybe
+import qualified Data.Map as M
 
 enumWithOneRegularField :: AnnASTElement SemanticAnns
 enumWithOneRegularField = TypeDefinition
@@ -35,14 +37,14 @@ enumWithMultipleParameterizedFields = TypeDefinition
     EnumVariant "variant3" [Int8, Vector (Vector Char (K 20)) (K 35)]
   ] []) undefined
 
-renderTypedefDeclaration :: AnnASTElement SemanticAnns -> Text
-renderTypedefDeclaration = render . fromJust .ppHeaderASTElement
+renderTypedefDeclaration :: OptionMap -> AnnASTElement SemanticAnns -> Text
+renderTypedefDeclaration opts = render . fromJust . (ppHeaderASTElement opts)
 
 spec :: Spec
 spec = do
   describe "Pretty printing enums" $ do
     it "Prints an enum with one regular variant" $ do
-      renderTypedefDeclaration enumWithOneRegularField `shouldBe`
+      renderTypedefDeclaration M.empty enumWithOneRegularField `shouldBe`
         pack (
             "typedef enum {\n" ++
             "    id0__variant0\n" ++
@@ -54,7 +56,7 @@ spec = do
             "\n" ++
             "} id0;\n")
     it "Prints an enum with two regular variants" $ do
-      renderTypedefDeclaration enumWithTwoRegularFields `shouldBe`
+      renderTypedefDeclaration M.empty enumWithTwoRegularFields `shouldBe`
         pack (
             "typedef enum {\n" ++
             "    id0__variant0,\n" ++
@@ -67,7 +69,7 @@ spec = do
             "\n" ++
             "} id0;\n")
     it "Prints an enum with one parameterized variant" $ do
-      renderTypedefDeclaration enumWithOneParameterizedField `shouldBe`
+      renderTypedefDeclaration M.empty enumWithOneParameterizedField `shouldBe`
         pack (
             "typedef enum {\n" ++
             "    id0__variant0\n" ++
@@ -85,7 +87,7 @@ spec = do
             "\n" ++
             "} id0;\n")
     it "Prints an enum with multiple parameterized variants" $ do
-      renderTypedefDeclaration enumWithMultipleParameterizedFields `shouldBe`
+      renderTypedefDeclaration M.empty enumWithMultipleParameterizedFields `shouldBe`
         pack (
             "typedef enum {\n" ++
             "    id0__variant0,\n" ++

--- a/test/UT/PPrinter/TypeDef/StructSpec.hs
+++ b/test/UT/PPrinter/TypeDef/StructSpec.hs
@@ -5,7 +5,10 @@ import PPrinter
 import AST.Seman
 import Data.Text
 import Semantic.Monad
+import Semantic.Option (OptionMap)
 import Data.Maybe
+import qualified Data.Map as M
+import qualified Data.Set as S
 
 {- | Struct type with a single field.
 In Termina's context sytax:
@@ -85,27 +88,39 @@ packedAndAlignedStruct = TypeDefinition
       Modifier "align" (Just (KC (I UInt32 16)))
     ]) undefined
 
-renderTypedefDeclaration :: AnnASTElement SemanticAnns -> Text
-renderTypedefDeclaration = render . fromJust . ppHeaderASTElement
+renderTypedefDeclaration :: OptionMap -> AnnASTElement SemanticAnns -> Text
+renderTypedefDeclaration opts = render . fromJust . (ppHeaderASTElement opts)
 
 spec :: Spec
 spec = do
   describe "Pretty printing Structs" $ do
     it "Prints a struct with just one field" $ do
-       renderTypedefDeclaration structWithOneField `shouldBe`
+       renderTypedefDeclaration (M.fromList [(DefinedType "id0", S.fromList [DefinedType "id0"])]) structWithOneField `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
-            "} id0;\n")
+            "} id0;\n" ++
+            "\n" ++
+            "typedef struct {\n" ++
+            "    id0 __0;\n" ++
+            "} __option_id0_params_t;\n" ++
+            "\n" ++     
+            "typedef struct {\n" ++
+            "\n" ++         
+            "    __option_id0_params_t Some;\n" ++
+            "\n" ++     
+            "    __enum_option_t __variant;\n" ++
+            "\n" ++     
+            "} __option_id0_t;\n")
     it "Prints a struct with two fields" $ do
-      renderTypedefDeclaration structWithTwoFields `shouldBe`
+      renderTypedefDeclaration M.empty structWithTwoFields `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
             "    uint16_t field1;\n" ++
             "} id0;\n")
     it "Prints a packed struct" $ do
-      renderTypedefDeclaration packedStruct `shouldBe`
+      renderTypedefDeclaration M.empty packedStruct `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
@@ -113,7 +128,7 @@ spec = do
             "    uint32_t field2[10];\n" ++
             "} __attribute__((packed)) id0;\n")
     it "Prints an aligned struct" $ do
-      renderTypedefDeclaration alignedStruct `shouldBe`
+      renderTypedefDeclaration M.empty alignedStruct `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++
@@ -121,7 +136,7 @@ spec = do
             "    uint32_t field2[10];\n" ++
             "} __attribute__((align(16))) id0;\n")
     it "Prints a packet & aligned struct" $ do
-      renderTypedefDeclaration packedAndAlignedStruct `shouldBe`
+      renderTypedefDeclaration M.empty packedAndAlignedStruct `shouldBe`
         pack (
             "typedef struct {\n" ++
             "    uint8_t field0;\n" ++


### PR DESCRIPTION
Until now, the Option type was not really polymorphic: it could only be used with dynamic subtypes (e.g., Option<dyn u32>. Now, the Option type is fully polymorphic: you can define an Option of any simple type. To make this new implementation work, the transpiler has been modified to generate a structure for each use of the polymorphic type that can be made. For example, *for each of these types*:

- `Option<u32>`
- `Option<[u32; 10]>`
- `Option <[[u32; 10]; 10]>`

a structure containing two fields is defined: one to store the value corresponding to the `Some` variant and another with the enum indicating whether the value is valid (`Some`) or not (`None`). These structures are defined on-demand only. Options of non-dynamic types can be used as any other simple type, that is, to declare variables, input parameters and fields of structures and classes. It is necessary to review the type checker code to check that all the present rules are still in effect and that the new ones are implemented.

This new feature implies a modification in the use of message queues. Message queues can now receive dynamic objects or simple objects. In the case of receiving simple objects, the object is copied to the message queue and, therefore, the ownership of the object is not lost.

The change has required the modification of several points of the code, i.e.,

- Once the modules are typed, and after doing the DF check, the code of all the modules is traversed generating a map containing the Options defined for each type. This map, in turn, is partitioned into two: one for the basic types (integer, char and bool), and another for the user-defined types. In order to avoid duplicates and not to generate the same structure multiple times, the elements of the map are sets of types. The code that searches for Option types is located in `src/Semantic/Option.hs`.
- The printer of the type definition code has been modified: if the code incorporates the use of an Option containing a user-defined type (struct or enum), the transpiler will generate the corresponding structures after those of the new type. To know if it has to generate any Option structure for a given type, the `ppTypeDefDeclaration()` function receives the map with the Option types.
- The type checking of the `send` procedure of message queues has been modified to force the first parameter to always be an object. This is necessary because, being a polymorphic procedure, the resulting function in C actually receives the object by reference, that is, although in termina the object is not passed by reference, in C it is. Therefore, it is not possible to pass as parameter any expression, since the operator `&` in C does not allow to obtain the addresses of anonymous objects, e.g.: `send(&get_integer())` is not valid in C (nor in termina).
- Options can now be of any simple type except an Option type, i.e., nested Options are not allowed, e.g. `Option<Option<u32>>` is not a valid type.

The tests have been modified to adapt them to the new definitions. Further testing is needed to fully validate the new implementation and to check that the other components of the transpiler (type checker and DF) behave as expected.

All tests pass.